### PR TITLE
Add cache-control headers and create immutable resource links

### DIFF
--- a/amt/api/http_browser_caching.py
+++ b/amt/api/http_browser_caching.py
@@ -1,0 +1,87 @@
+import os
+import urllib
+from functools import lru_cache
+from os import PathLike
+from pathlib import Path
+from typing import NamedTuple
+from urllib.parse import ParseResult, urlencode
+
+from starlette._compat import md5_hexdigest
+from starlette.responses import Response
+from starlette.staticfiles import StaticFiles
+from starlette.types import Scope
+
+
+class StaticFilesCache(StaticFiles):
+    def __init__(
+        self,
+        *,
+        directory: PathLike[str] | None = None,
+        packages: list[str | tuple[str, str]] | None = None,
+        html: bool = False,
+        check_dir: bool = True,
+        follow_symlink: bool = False,
+        immutable_cache_control: str = "public, max-age=31536000, immutable",
+        temporary_cache_control: str = "public, max-age=3600, must-revalidate",
+    ) -> None:
+        self.immutable_cache_control = immutable_cache_control
+        self.temporary_cache_control = temporary_cache_control
+        super().__init__(
+            directory=directory, packages=packages, html=html, check_dir=check_dir, follow_symlink=follow_symlink
+        )
+
+    def file_response(  # pyright: ignore [reportIncompatibleMethodOverride]
+        self,
+        full_path: PathLike,  # pyright: ignore
+        stat_result: os.stat_result,
+        scope: Scope,
+        status_code: int = 200,
+    ) -> Response:
+        resp: Response = super().file_response(
+            full_path=full_path,  # pyright: ignore [reportUnknownArgumentType]
+            stat_result=stat_result,
+            scope=scope,
+            status_code=status_code,
+        )
+        if b"etag=" in scope["query_string"]:
+            resp.headers.setdefault("Cache-Control", self.immutable_cache_control)
+        else:
+            resp.headers.setdefault("Cache-Control", self.temporary_cache_control)
+        return resp
+
+
+class URLComponents(NamedTuple):
+    schema: str
+    netloc: str
+    url: str
+    path: str
+    query: str
+    fragment: str
+
+
+@lru_cache(maxsize=1000)
+def url_for_cache(name: str, /, **path_params: str) -> str:
+    if name != "static":
+        raise ValueError("Only static files are supported.")
+
+    url_parts: ParseResult = urllib.parse.urlparse(path_params["path"])  # type: ignore
+    if url_parts.scheme or url_parts.hostname:  # type: ignore
+        raise ValueError("Only local URLS are supported.")
+
+    query_list: dict[str, str] = dict(x.split("=") for x in url_parts.query.split("&")) if url_parts.query else {}  # type: ignore
+    resolved_url_path: str = "/" + name + "/" + url_parts.path  # type: ignore
+    _, stat_result = static_files.lookup_path(url_parts.path)  # type: ignore
+    if not stat_result:
+        raise ValueError("Static file not found.")
+
+    etag_base = str(stat_result.st_mtime) + "-" + str(stat_result.st_size)
+    etag = f"{md5_hexdigest(etag_base.encode(), usedforsecurity=False)}"
+    query_list["etag"] = etag
+
+    return_url = urllib.parse.urlunparse(  # type: ignore
+        URLComponents("", "", resolved_url_path, "", urlencode(query_list), "")
+    )
+    return str(return_url)  # type: ignore
+
+
+static_files = StaticFilesCache(directory=Path("amt/site/static"))

--- a/amt/server.py
+++ b/amt/server.py
@@ -5,7 +5,6 @@ from contextlib import asynccontextmanager
 from fastapi import FastAPI, Request
 from fastapi.exceptions import RequestValidationError
 from fastapi.responses import HTMLResponse
-from fastapi.staticfiles import StaticFiles
 from starlette.exceptions import HTTPException as StarletteHTTPException
 
 from amt.api.main import api_router
@@ -20,6 +19,7 @@ from amt.core.exception_handlers import (
 from amt.core.log import configure_logging
 from amt.utils.mask import Mask
 
+from .api.http_browser_caching import static_files
 from .middleware.route_logging import RequestLoggingMiddleware
 
 configure_logging(get_settings().LOGGING_LEVEL, get_settings().LOGGING_CONFIG)
@@ -53,7 +53,7 @@ app = FastAPI(
 )
 
 app.add_middleware(RequestLoggingMiddleware)
-app.mount("/static", StaticFiles(directory="amt/site/static/"), name="static")
+app.mount("/static", static_files, name="static")
 
 
 @app.exception_handler(StarletteHTTPException)

--- a/amt/site/templates/default_header.html.j2
+++ b/amt/site/templates/default_header.html.j2
@@ -1,7 +1,7 @@
 <header class="header">
     <div class="container">
         <div class="header_logo_container">
-            <img class="header_logo_image" src="/static/images/logo.svg"/>
+            <img class="header_logo_image" src="{{ url_for_cache('static', path='images/logo.svg') }}"/>
             <div class="header_subtitle_container">
                 <span>{% trans %}Algorithm Management Toolkit{% endtrans %} ({{ version }})</span>
             </div>

--- a/amt/site/templates/layouts/base.html.j2
+++ b/amt/site/templates/layouts/base.html.j2
@@ -1,23 +1,23 @@
 <!DOCTYPE html>
 <html lang="{{ language }}">
 <head>
-    <link rel="icon" type="image/x-icon" href="/static/favicon.ico">
+    <link rel="icon" type="image/x-icon" href="{{ url_for_cache('static', path='favicon.ico') }}">
     <title>
         {% block title %}
             {% trans %}Algorithmic Management Toolkit (AMT){% endtrans %}
         {% endblock %}
     </title>
     {% block scripts %}
-    <script type="text/javascript" src="/static/vendor/sortable/js/sortable.js"></script>
-    <script type="text/javascript" src="/static/vendor/htmx/js/hyperscript.min.js"></script>
-    <script type="text/javascript" src="/static/vendor/htmx/js/1.9.12.min.js"></script>
-    <script type="text/javascript" src="/static/vendor/htmx/js/json-enc.js"></script>
-    <script type="text/javascript" src="/static/vendor/htmx/js/response-targets.js"></script>
-    <script type="text/javascript" src="/static/js/amt.js"></script>
+    <script type="text/javascript" src="{{ url_for_cache('static', path='vendor/sortable/js/sortable.js') }}"></script>
+    <script type="text/javascript" src="{{ url_for_cache('static', path='vendor/htmx/js/hyperscript.min.js') }}"></script>
+    <script type="text/javascript" src="{{ url_for_cache('static', path='vendor/htmx/js/1.9.12.min.js') }}"></script>
+    <script type="text/javascript" src="{{ url_for_cache('static', path='vendor/htmx/js/json-enc.js') }}"></script>
+    <script type="text/javascript" src="{{ url_for_cache('static', path='vendor/htmx/js/response-targets.js') }}"></script>
+    <script type="text/javascript" src="{{ url_for_cache('static', path='js/amt.js') }}"></script>
     {% endblock %}
     {% block styles %}
-    <link rel="stylesheet" href="/static/css/html5reset.css"/>
-    <link rel="stylesheet" href="/static/css/layout.css"/>
+    <link rel="stylesheet" href="{{ url_for_cache('static', path='css/html5reset.css') }}"/>
+    <link rel="stylesheet" href="{{ url_for_cache('static', path='css/layout.css') }}"/>
     {% endblock %}
 </head>
 <body hx-ext="response-targets">

--- a/amt/site/templates/macros/render.html.j2
+++ b/amt/site/templates/macros/render.html.j2
@@ -28,7 +28,7 @@
     <div>{{ task.description }}</div>
     {% if task.user_id %}
     <div class="progress_card_assignees_container">
-        <img class="progress_card_assignees_image" src="/static/images/img_avatar.png" alt="Assigned to Avatar" />
+        <img class="progress_card_assignees_image" src="{{ url_for_cache('static', path='images/img_avatar.png') }}" alt="Assigned to Avatar" />
     </div>
     {% endif %}
 </div>

--- a/amt/site/templates/pages/index.html.j2
+++ b/amt/site/templates/pages/index.html.j2
@@ -3,18 +3,18 @@
 
 {% block styles %}
     {{ super() }}
-    <link rel="stylesheet" href="/static/css/col.css"/>
-    <link rel="stylesheet" href="/static/css/2cols.css"/>
-    <link rel="stylesheet" href="/static/css/3cols.css"/>
-    <link rel="stylesheet" href="/static/css/4cols.css"/>
-    <link rel="stylesheet" href="/static/css/5cols.css"/>
-    <link rel="stylesheet" href="/static/css/6cols.css"/>
-    <link rel="stylesheet" href="/static/css/7cols.css"/>
-    <link rel="stylesheet" href="/static/css/8cols.css"/>
-    <link rel="stylesheet" href="/static/css/9cols.css"/>
-    <link rel="stylesheet" href="/static/css/10cols.css"/>
-    <link rel="stylesheet" href="/static/css/11cols.css"/>
-    <link rel="stylesheet" href="/static/css/12cols.css"/>
+    <link rel="stylesheet" href="{{ url_for_cache('static', path='css/col.css') }} "/>
+    <link rel="stylesheet" href="{{ url_for_cache('static', path='css/2cols.css') }}"/>
+    <link rel="stylesheet" href="{{ url_for_cache('static', path='css/3cols.css') }}"/>
+    <link rel="stylesheet" href="{{ url_for_cache('static', path='css/4cols.css') }}"/>
+    <link rel="stylesheet" href="{{ url_for_cache('static', path='css/5cols.css') }}"/>
+    <link rel="stylesheet" href="{{ url_for_cache('static', path='css/6cols.css') }}"/>
+    <link rel="stylesheet" href="{{ url_for_cache('static', path='css/7cols.css') }}"/>
+    <link rel="stylesheet" href="{{ url_for_cache('static', path='css/8cols.css') }}"/>
+    <link rel="stylesheet" href="{{ url_for_cache('static', path='css/9cols.css') }}"/>
+    <link rel="stylesheet" href="{{ url_for_cache('static', path='css/10cols.css') }}"/>
+    <link rel="stylesheet" href="{{ url_for_cache('static', path='css/11cols.css') }}"/>
+    <link rel="stylesheet" href="{{ url_for_cache('static', path='css/12cols.css') }}"/>
 {% endblock %}
 
 {% block content %}

--- a/tests/api/test_http_browser_caching.py
+++ b/tests/api/test_http_browser_caching.py
@@ -1,0 +1,61 @@
+import os
+from pathlib import Path
+from typing import NamedTuple
+from unittest.mock import Mock
+
+import pytest
+from amt.api import http_browser_caching
+from starlette.responses import Response
+
+
+def test_url_for_cache_not_static():
+    with pytest.raises(ValueError, match="Only static files are supported."):
+        http_browser_caching.url_for_cache("not-static")
+
+
+def test_url_for_cache_not_local():
+    with pytest.raises(ValueError, match="Only local URLS are supported."):
+        http_browser_caching.url_for_cache("static", path="http://this.is.not.local")
+
+
+def test_url_for_cache_file_not_found():
+    with pytest.raises(ValueError, match="Static file not found."):
+        http_browser_caching.url_for_cache("static", path="this/does/not/exist")
+
+
+def test_url_for_cache_file_happy_flow(tmp_path: Path):
+    class MockStatResult(NamedTuple):
+        st_mtime: int
+        st_size: int
+
+    lookup_path_orig = http_browser_caching.static_files.lookup_path
+    (tmp_path / "testfile").write_text("This is a test", encoding="utf-8")
+    http_browser_caching.static_files = http_browser_caching.StaticFilesCache(directory=Path(tmp_path))
+    http_browser_caching.static_files.lookup_path = Mock(os.stat_result, return_value=(None, MockStatResult(1, 2)))
+    result = http_browser_caching.url_for_cache("static", path="testfile")
+    assert result == "/static/testfile?etag=98c6f2c2287f4c73cea3d40ae7ec3ff2"
+    # also test with a query param
+    result = http_browser_caching.url_for_cache("static", path="testfile?queryparam1=true")
+    assert result == "/static/testfile?queryparam1=true&etag=98c6f2c2287f4c73cea3d40ae7ec3ff2"
+
+    http_browser_caching.static_files.lookup_path = lookup_path_orig
+
+
+def test_static_files_class_immutable(tmp_path: Path):
+    testfile = tmp_path / "testfile"
+    testfile.write_text("This is a test", encoding="utf-8")
+    static_files = http_browser_caching.StaticFilesCache(directory=Path(tmp_path))
+    stat_result = os.stat(testfile)
+    response: Response = static_files.file_response(  #  pyright: ignore [reportUnknownMemberType]
+        testfile, stat_result, {"headers": [], "query_string": b"etag=value-for-testing"}
+    )
+    assert b"cache-control", b"public, max-age=31536000, immutable" in response.headers
+
+
+def test_static_files_class_temporary(tmp_path: Path):
+    testfile = tmp_path / "testfile"
+    testfile.write_text("This is a test", encoding="utf-8")
+    static_files = http_browser_caching.StaticFilesCache(directory=Path(tmp_path))
+    stat_result = os.stat(testfile)
+    response: Response = static_files.file_response(testfile, stat_result, {"headers": [], "query_string": b""})  #  pyright: ignore [reportUnknownMemberType]
+    assert b"cache-control", b"public, max-age=3600, must-revalidate" in response.headers

--- a/tests/site/static/templates/test_template_headers.py
+++ b/tests/site/static/templates/test_template_headers.py
@@ -1,0 +1,13 @@
+from amt.api.deps import templates
+from tests.constants import default_fastapi_request
+
+
+def test_template_caching():
+    # given
+    request = default_fastapi_request()
+
+    # when
+    response = templates.TemplateResponse(request, "error.html.j2", headers={"Content-Language": "This is a test"})
+
+    # then
+    assert response.headers["Content-Language"] == "This is a test"


### PR DESCRIPTION
# Description

Add cache-control headers to the HTTP responses and generate unique immutable cache URLS for static resources we use directly.

Resolves #86

## Checklist

Please check all the boxes that apply to this pull request using "x":

- [X]  I have tested the changes locally and verified that they work as expected.
- [X]  I have followed the project's coding conventions and style guidelines.
- [X]  I have rebased my branch onto the latest commit of the main branch.
- [X]  I have squashed or reorganized my commits into logical units.
- [X]  I have read, understood and agree to the [Developer Certificate of Origin](../blob/main/DCO.md), which this project utilizes.
