### PR TITLE
87 add csrf tokens to forms

### DIFF
--- a/amt/api/deps.py
+++ b/amt/api/deps.py
@@ -69,7 +69,7 @@ class LocaleJinja2Templates(Jinja2Templates):
 
         if context is None:
             context = {}
-
+        context["csrftoken"] = request.state.csrftoken
         return super().TemplateResponse(request, name, context, status_code, headers, media_type, background)
 
     def Redirect(self, request: Request, url: str) -> HTMLResponse:

--- a/amt/api/routes/projects.py
+++ b/amt/api/routes/projects.py
@@ -37,8 +37,8 @@ async def get_new(
     instrument_service: Annotated[InstrumentsService, Depends(InstrumentsService)],
 ) -> HTMLResponse:
     instruments = instrument_service.fetch_instruments()
-
-    return templates.TemplateResponse(request, "projects/new.html.j2", {"instruments": instruments})
+    response = templates.TemplateResponse(request, "projects/new.html.j2", {"instruments": instruments})
+    return response
 
 
 @router.post("/new", response_class=HTMLResponse)
@@ -48,5 +48,5 @@ async def post_new(
     projects_service: Annotated[ProjectsService, Depends(ProjectsService)],
 ) -> HTMLResponse:
     project = projects_service.create(project_new)
-
-    return templates.Redirect(request, f"/project/{project.id}")
+    response = templates.Redirect(request, f"/project/{project.id}")
+    return response

--- a/amt/core/config.py
+++ b/amt/core/config.py
@@ -15,6 +15,7 @@ from amt.core.types import DatabaseSchemaType, EnvironmentType, LoggingLevelType
 
 logger = logging.getLogger(__name__)
 
+
 # Self type is not available in Python 3.10 so create our own with TypeVar
 SelfSettings = TypeVar("SelfSettings", bound="Settings")
 
@@ -49,6 +50,12 @@ class Settings(BaseSettings):
     APP_DATABASE_FILE: str = "/database.sqlite3"
 
     model_config = SettingsConfigDict(extra="ignore")
+
+    # FastAPI CSRF Protect Settings
+    CSRF_PROTECT_SECRET_KEY: str = secrets.token_urlsafe(32)
+    CSRF_TOKEN_LOCATION: str = "header"
+    CSRF_TOKEN_KEY: str = "csrf-token"
+    CSRF_COOKIE_SAMESITE: str = "strict"
 
     @computed_field
     def SQLALCHEMY_ECHO(self) -> bool:

--- a/amt/core/csrf.py
+++ b/amt/core/csrf.py
@@ -1,0 +1,18 @@
+from typing import Any
+
+from fastapi_csrf_protect import CsrfProtect  # type: ignore
+
+from amt.core.config import get_settings
+
+
+@CsrfProtect.load_config  # type: ignore
+def get_csrf_config() -> list[tuple[Any, ...]]:
+    settings = get_settings()
+    config = [
+        ("secret_key", settings.CSRF_PROTECT_SECRET_KEY),
+        ("token_location", settings.CSRF_TOKEN_LOCATION),
+        ("token_key", settings.CSRF_TOKEN_KEY),
+        ("cookie_samesite", settings.CSRF_COOKIE_SAMESITE),
+    ]
+
+    return config

--- a/amt/middleware/csrf.py
+++ b/amt/middleware/csrf.py
@@ -1,0 +1,76 @@
+import logging
+import typing
+
+from fastapi_csrf_protect import CsrfProtect  # type: ignore
+from fastapi_csrf_protect.exceptions import CsrfProtectError  # type: ignore
+from starlette.middleware.base import BaseHTTPMiddleware
+from starlette.requests import Request
+from starlette.responses import Response
+from starlette.types import ASGIApp
+
+from amt.core.csrf import get_csrf_config  # type: ignore # noqa
+from amt.core.exception_handlers import csrf_protect_exception_handler
+
+RequestResponseEndpoint = typing.Callable[[Request], typing.Awaitable[Response]]
+
+
+logger = logging.getLogger(__name__)
+
+
+class CSRFMiddleware(BaseHTTPMiddleware):
+    """
+    This middleware implements CSRF signed double token protection through FastAPI CSRF Protect.
+    """
+
+    def __init__(self, app: ASGIApp) -> None:
+        super().__init__(app)
+        self.csrf_protect = CsrfProtect()
+        self.safe_methods = ("GET", "HEAD", "OPTIONS", "TRACE")
+
+    def _include_request(self, request: Request) -> bool:
+        """
+        This method specifies whether a request should be protected by FastAPI CSRF Protect or not.
+        The method is needed because we need to in any case exclude GET requests originating from
+        HTMX or GET requests that fetch static pages becauses this will result in multiple tokens
+        which make validation impossible due to the asynchronisity of the requests.
+        """
+        is_not_static: bool = "static" not in request.url.path
+        is_not_htmx: bool = request.state.htmx == "False"
+        return is_not_static or is_not_htmx
+
+    async def dispatch(self, request: Request, call_next: RequestResponseEndpoint) -> Response:
+        signed_token = ""
+        if self._include_request(request):
+            request.state.csrftoken = ""
+            if request.method in self.safe_methods:
+                csrf_token, signed_token = self.csrf_protect.generate_csrf_tokens()
+                logger.debug(f"generating tokens: csrf_token={csrf_token}, signed_token={signed_token}")
+                request.state.csrftoken = csrf_token
+            else:
+                csrf_token = request.headers["X-CSRF-Token"]
+                logger.debug(f"validating tokens: csrf_token={csrf_token}")
+                await self.csrf_protect.validate_csrf(request)
+
+        response = await call_next(request)
+
+        if self._include_request(request) and request.method in self.safe_methods:
+            self.csrf_protect.set_csrf_cookie(signed_token, response)
+            logger.debug(f"set csrf_cookie: signed_token={signed_token}")
+
+        return response
+
+
+class CSRFMiddlewareExceptionHandler(BaseHTTPMiddleware):
+    """
+    This middleware is necessary to propagate CsrfProtectErrors to the csrf_protection_handler.
+    """
+
+    def __init__(self, app: ASGIApp) -> None:
+        super().__init__(app)
+
+    async def dispatch(self, request: Request, call_next: RequestResponseEndpoint) -> Response:
+        try:
+            response = await call_next(request)
+        except CsrfProtectError as e:
+            return await csrf_protect_exception_handler(request, e)
+        return response

--- a/amt/middleware/htmx.py
+++ b/amt/middleware/htmx.py
@@ -1,3 +1,4 @@
+import logging
 import typing
 
 from starlette.middleware.base import BaseHTTPMiddleware
@@ -5,6 +6,8 @@ from starlette.requests import Request
 from starlette.responses import Response
 
 RequestResponseEndpoint = typing.Callable[[Request], typing.Awaitable[Response]]
+
+logger = logging.getLogger(__name__)
 
 
 class HTMXMiddleware(BaseHTTPMiddleware):

--- a/amt/server.py
+++ b/amt/server.py
@@ -20,6 +20,7 @@ from amt.core.log import configure_logging
 from amt.utils.mask import Mask
 
 from .api.http_browser_caching import static_files
+from .middleware.csrf import CSRFMiddleware, CSRFMiddlewareExceptionHandler
 from .middleware.htmx import HTMXMiddleware
 from .middleware.route_logging import RequestLoggingMiddleware
 
@@ -54,6 +55,8 @@ def create_app() -> FastAPI:
     )
 
     app.add_middleware(RequestLoggingMiddleware)
+    app.add_middleware(CSRFMiddleware)
+    app.add_middleware(CSRFMiddlewareExceptionHandler)
     app.add_middleware(HTMXMiddleware)
 
     app.mount("/static", static_files, name="static")

--- a/amt/site/templates/errors/CsrfProtectError.html.j2
+++ b/amt/site/templates/errors/CsrfProtectError.html.j2
@@ -1,0 +1,5 @@
+{% extends 'layouts/base.html.j2' %}
+
+{% block content %}
+{% include 'errors/_CsrfProtectError.html.j2' %}
+{% endblock %}

--- a/amt/site/templates/errors/_CsrfProtectError.html.j2
+++ b/amt/site/templates/errors/_CsrfProtectError.html.j2
@@ -1,0 +1,2 @@
+<h2>{{status_code}}</h2>
+<p>{{status_message}}</p>

--- a/amt/site/templates/pages/index.html.j2
+++ b/amt/site/templates/pages/index.html.j2
@@ -20,7 +20,7 @@
 
 {% block content %}
 <div class="container">
-    <form id="cardMovedForm" hx-patch="/tasks/" hx-ext="json-enc" hx-target-5*="#errorContainer"  hx-trigger="cardmoved" hx-swap="outerHTML" hx-target="#board" class="">
+    <form id="cardMovedForm" hx-patch="/tasks/" hx-ext="json-enc" hx-headers='{"X-CSRF-Token": "{{ csrftoken }}"}' hx-target-5*="#errorContainer"  hx-trigger="cardmoved" hx-swap="outerHTML" hx-target="#board" class="">
         <input type="hidden" name="taskId" value="">
         <input type="hidden" name="statusId" value="">
         <input type="hidden" name="previousSiblingId" value="">

--- a/amt/site/templates/projects/new.html.j2
+++ b/amt/site/templates/projects/new.html.j2
@@ -3,7 +3,7 @@
 {% block content %}
     <h1 class="margin-bottom--large">{% trans %}New Project{% endtrans %}</h1>
 
-    <form hx-ext="json-enc" hx-post="/projects/new" hx-target-error="#errorContainer" hx-swap="innerHTML" method="post">
+    <form hx-ext="json-enc" hx-post="/projects/new" hx-headers='{"X-CSRF-Token": "{{ csrftoken }}"}' hx-target-error="#errorContainer" hx-swap="innerHTML" method="post">
         {% trans %}Project name{% endtrans %} <input type="text" id="name" name="name">
 
         <fieldset>

--- a/poetry.lock
+++ b/poetry.lock
@@ -342,6 +342,23 @@ all = ["email_validator (>=2.0.0)", "fastapi-cli[standard] (>=0.0.5)", "httpx (>
 standard = ["email_validator (>=2.0.0)", "fastapi-cli[standard] (>=0.0.5)", "httpx (>=0.23.0)", "jinja2 (>=2.11.2)", "python-multipart (>=0.0.7)", "uvicorn[standard] (>=0.12.0)"]
 
 [[package]]
+name = "fastapi-csrf-protect"
+version = "0.3.4"
+description = "Stateless implementation of Cross-Site Request Forgery (XSRF) Protection by using Double Submit Cookie mitigation pattern"
+optional = false
+python-versions = "<4.0,>=3.8"
+files = [
+    {file = "fastapi_csrf_protect-0.3.4-py3-none-any.whl", hash = "sha256:78ee1d5bcdc10d06f0516fa8ed9e00b4fa8c8dfa8e93bada6ede7a7bba7507ae"},
+    {file = "fastapi_csrf_protect-0.3.4.tar.gz", hash = "sha256:a7d170d4e119c22bae8a4f5922529767f4d69c4c69744865c03f939e399e5822"},
+]
+
+[package.dependencies]
+fastapi = ">=0,<1"
+itsdangerous = ">=2.0.1,<3.0.0"
+pydantic = ">=2.0.0,<3.0.0"
+pydantic-settings = ">=2.0.0,<3.0.0"
+
+[[package]]
 name = "filelock"
 version = "3.15.4"
 description = "A platform independent file lock."
@@ -605,6 +622,17 @@ python-versions = ">=3.7"
 files = [
     {file = "iniconfig-2.0.0-py3-none-any.whl", hash = "sha256:b6a85871a79d2e3b22d2d1b94ac2824226a63c6b741c88f7ae975f18b6778374"},
     {file = "iniconfig-2.0.0.tar.gz", hash = "sha256:2d91e135bf72d31a410b17c16da610a82cb55f6b0477d1a902134b24a455b8b3"},
+]
+
+[[package]]
+name = "itsdangerous"
+version = "2.2.0"
+description = "Safely pass data to untrusted environments and back."
+optional = false
+python-versions = ">=3.8"
+files = [
+    {file = "itsdangerous-2.2.0-py3-none-any.whl", hash = "sha256:c6242fc49e35958c8b15141343aa660db5fc54d4f13a1db01a3f5891b98700ef"},
+    {file = "itsdangerous-2.2.0.tar.gz", hash = "sha256:e0050c0b7da1eea53ffaf149c0cfbb5c6e2e2b69c4bef22c81fa6eb73e5f6173"},
 ]
 
 [[package]]
@@ -1799,4 +1827,4 @@ files = [
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.10"
-content-hash = "8d9a0e2ff970256df9508680372d077229163364788a81e376799dc9a935ed26"
+content-hash = "4ef06f3d5fc3e52310e23ddeb22d1715f495349926e433f6228eeeb1d14bb47e"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,6 +36,7 @@ httpx = "^0.27.0"
 pyyaml-include = "^2.1"
 click = "^8.1.7"
 python-ulid = "^2.7.0"
+fastapi-csrf-protect = "^0.3.4"
 
 
 [tool.poetry.group.test.dependencies]

--- a/tests/api/routes/test_status.py
+++ b/tests/api/routes/test_status.py
@@ -1,3 +1,5 @@
+from collections.abc import Generator
+
 from amt.schema.task import MovedTask
 from fastapi.testclient import TestClient
 
@@ -5,22 +7,28 @@ from tests.constants import default_task
 from tests.database_test_utils import DatabaseTestUtils
 
 
-def test_post_move_task(client: TestClient, db: DatabaseTestUtils) -> None:
+def test_post_move_task(client: TestClient, db: DatabaseTestUtils, mock_csrf: Generator[None, None, None]) -> None:
     db.given([default_task(), default_task(), default_task()])
+    client.cookies["fastapi-csrf-token"] = "1"
 
     move_task: MovedTask = MovedTask(taskId=2, statusId=2, previousSiblingId=1, nextSiblingId=3)
 
-    response = client.patch("/tasks/", json=move_task.model_dump(by_alias=True))
+    response = client.patch("/tasks/", json=move_task.model_dump(by_alias=True), headers={"X-CSRF-Token": "1"})
     assert response.status_code == 200
     assert response.headers["content-type"] == "text/html; charset=utf-8"
     assert b'id="card-content-' in response.content
 
 
-def test_post_move_task_no_siblings(client: TestClient, db: DatabaseTestUtils) -> None:
+def test_post_move_task_no_siblings(
+    client: TestClient,
+    db: DatabaseTestUtils,
+    mock_csrf: Generator[None, None, None],
+) -> None:
     db.given([default_task(), default_task(), default_task()])
+    client.cookies["fastapi-csrf-token"] = "1"
 
     move_task: MovedTask = MovedTask(taskId=2, statusId=1, previousSiblingId=-1, nextSiblingId=-1)
-    response = client.patch("/tasks/", json=move_task.model_dump(by_alias=True))
+    response = client.patch("/tasks/", json=move_task.model_dump(by_alias=True), headers={"X-CSRF-Token": "1"})
 
     assert response.status_code == 200
     assert response.headers["content-type"] == "text/html; charset=utf-8"

--- a/tests/api/routes/test_tasks_move.py
+++ b/tests/api/routes/test_tasks_move.py
@@ -1,23 +1,31 @@
+from collections.abc import Generator
+
 from fastapi.testclient import TestClient
 
 from tests.constants import default_task
 from tests.database_test_utils import DatabaseTestUtils
 
 
-def test_post_task_move(client: TestClient, db: DatabaseTestUtils) -> None:
+def test_post_task_move(client: TestClient, db: DatabaseTestUtils, mock_csrf: Generator[None, None, None]) -> None:
     db.given([default_task(), default_task(), default_task()])
+    client.cookies["fastapi-csrf-token"] = "1"
 
     response = client.patch(
-        "/tasks/", json={"taskId": "1", "statusId": "1", "previousSiblingId": "2", "nextSiblingId": "-1"}
+        "/tasks/",
+        json={"taskId": "1", "statusId": "1", "previousSiblingId": "2", "nextSiblingId": "-1"},
+        headers={"X-CSRF-Token": "1"},
     )
     assert response.status_code == 200
     assert response.headers["content-type"] == "text/html; charset=utf-8"
     assert b'id="card-content-1"' in response.content
 
 
-def test_task_move_error(client: TestClient, db: DatabaseTestUtils) -> None:
+def test_task_move_error(client: TestClient, db: DatabaseTestUtils, mock_csrf: Generator[None, None, None]) -> None:
+    client.cookies["fastapi-csrf-token"] = "1"
     response = client.patch(
-        "/tasks/", json={"taskId": "1", "statusId": "1", "previousSiblingId": "2", "nextSiblingId": "-1"}
+        "/tasks/",
+        json={"taskId": "1", "statusId": "1", "previousSiblingId": "2", "nextSiblingId": "-1"},
+        headers={"X-CSRF-Token": "1"},
     )
     assert response.status_code == 500
     assert response.headers["content-type"] == "text/html; charset=utf-8"

--- a/tests/constants.py
+++ b/tests/constants.py
@@ -12,7 +12,9 @@ def default_project(name: str = "default project", model_card: str = "/tmp/1.yam
 
 
 def default_fastapi_request() -> Request:
-    return Request(scope={"type": "http", "http_version": "1.1", "method": "GET", "headers": []})
+    request = Request(scope={"type": "http", "http_version": "1.1", "method": "GET", "headers": []})
+    request.state.csrftoken = ""
+    return request
 
 
 def default_instrument(

--- a/tests/core/test_exception_handlers.py
+++ b/tests/core/test_exception_handlers.py
@@ -1,3 +1,4 @@
+from amt.schema.project import ProjectNew
 from fastapi import status
 from fastapi.testclient import TestClient
 
@@ -16,6 +17,16 @@ def test_request_validation_exception_handler(client: TestClient):
     assert response.headers["content-type"] == "text/html; charset=utf-8"
 
 
+def test_request_csrf_protect_exception_handler_invalid_token_in_header(client: TestClient):
+    data = client.get("/projects/new")
+    new_project = ProjectNew(name="default project")
+    response = client.post(
+        "/projects/new", json=new_project.model_dump(), headers={"X-CSRF-Token": "1"}, cookies=data.cookies
+    )
+    assert response.status_code == status.HTTP_401_UNAUTHORIZED
+    assert response.headers["content-type"] == "text/html; charset=utf-8"
+
+
 def test_http_exception_handler_htmx(client: TestClient):
     response = client.get("/raise-http-exception", headers={"HX-Request": "true"})
 
@@ -24,6 +35,27 @@ def test_http_exception_handler_htmx(client: TestClient):
 
 
 def test_request_validation_exception_handler_htmx(client: TestClient):
+    response = client.get("/projects/?skip=a", headers={"HX-Request": "true"})
+
+    assert response.status_code == status.HTTP_400_BAD_REQUEST
+    assert response.headers["content-type"] == "text/html; charset=utf-8"
+
+
+def test_request_csrf_protect_exception_handler_invalid_token_in_header_htmx(client: TestClient):
+    data = client.get("/projects/new")
+    new_project = ProjectNew(name="default project")
+    response = client.post(
+        "/projects/new",
+        json=new_project.model_dump(),
+        headers={"HX-Request": "true", "X-CSRF-Token": "1"},
+        cookies=data.cookies,
+    )
+
+    assert response.status_code == status.HTTP_401_UNAUTHORIZED
+    assert response.headers["content-type"] == "text/html; charset=utf-8"
+
+
+def test_(client: TestClient):
     response = client.get("/projects/?skip=a", headers={"HX-Request": "true"})
 
     assert response.status_code == status.HTTP_400_BAD_REQUEST

--- a/tests/site/static/templates/test_template_new_project.py
+++ b/tests/site/static/templates/test_template_new_project.py
@@ -5,7 +5,7 @@ from tests.constants import default_fastapi_request
 def test_tempate_projects_new():
     # given
     request = default_fastapi_request()
-    context = {"project": ""}
+    context = {"project": "", "instruments": ""}
 
     # when
     response = templates.TemplateResponse(request, "projects/new.html.j2", context)


### PR DESCRIPTION
# Add CSRF Tokens to projects/new post request

Adds CSRF protection via [fastapi CSRF Token Protect](https://pypi.org/project/fastapi-csrf-protect/) (implementing double submit cookies) to the `projects/new` post request as a middleware layer.

Resolves #87 

## Checklist

Please check all the boxes that apply to this pull request using "x":

- [x]  I have tested the changes locally and verified that they work as expected.
- [x]  I have followed the project's coding conventions and style guidelines.
- [x]  I have rebased my branch onto the latest commit of the main branch.
- [x]  I have squashed or reorganized my commits into logical units.
- [x]  I have read, understood and agree to the [Developer Certificate of Origin](../blob/main/DCO.md), which this project utilizes.
