### PR TITLE
Run when PR is merged

### DIFF
--- a/.github/workflows/ghcr-cleaner.yml
+++ b/.github/workflows/ghcr-cleaner.yml
@@ -5,6 +5,9 @@ on:
   pull_request:
     types:
       - closed
+  push:
+    branches:
+      - main
 
 jobs:
   delete_old_images:
@@ -20,7 +23,7 @@ jobs:
           token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: 'Clean up development images'
-        if: github.event_name == 'pull_request'
+        if: github.event_name == 'pull_request' && (github.event.action == 'closed' || github.event.pull_request.merged == true)
         uses: dataaxiom/ghcr-cleanup-action@v1
         with:
           tags: 'pr-${{github.event.pull_request.number}}'


### PR DESCRIPTION
# Description

The Github Action to clean up the container registry doesn't run when a PR is merged into main, this extra trigger would potentially help and solve this.

In the docs: https://docs.github.com/en/actions/writing-workflows/choosing-when-your-workflow-runs/events-that-trigger-workflows#pull_request
 
'''The pull_request webhook event payload is empty for merged pull requests and pull requests that come from forked repositories.'''

Inspiration taken from: https://github.com/orgs/community/discussions/26724

Link all GitHub issues fixed by this PR.
Make sure to first open an issue, get community approval and only then create Pull Request to resolve it.
All Pull Requests must have an issue attached to them

Resolves #

## Checklist

Please check all the boxes that apply to this pull request using "x":

- [x]  I have tested the changes locally and verified that they work as expected.
- [x]  I have followed the project's coding conventions and style guidelines.
- [x]  I have rebased my branch onto the latest commit of the main branch.
- [x]  I have squashed or reorganized my commits into logical units.
- [x]  I have read, understood and agree to the [Developer Certificate of Origin](../blob/main/DCO.md), which this project utilizes.
