### PR TITLE
Make title field for tasks a string of 1024 characters

### DIFF
--- a/amt/migrations/versions/66cf279a7f62_change_title_length_for_task.py
+++ b/amt/migrations/versions/66cf279a7f62_change_title_length_for_task.py
@@ -1,0 +1,34 @@
+"""change title length for task
+
+Revision ID: 66cf279a7f62
+Revises: 9ce2341f2922
+Create Date: 2024-08-13 15:33:28.001811
+
+"""
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision: str = "66cf279a7f62"
+down_revision: str | None = "9ce2341f2922"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    with op.batch_alter_table("task", schema=None) as batch_op:
+        batch_op.alter_column(
+            "title", existing_type=sa.VARCHAR(length=255), type_=sa.String(length=1024), existing_nullable=False
+        )
+
+
+def downgrade() -> None:
+    op.execute("UPDATE task SET title=SUBSTRING(title,1,255)")
+
+    with op.batch_alter_table("task", schema=None) as batch_op:
+        batch_op.alter_column(
+            "title", existing_type=sa.String(length=1024), type_=sa.VARCHAR(length=255), existing_nullable=False
+        )

--- a/amt/models/task.py
+++ b/amt/models/task.py
@@ -1,4 +1,4 @@
-from sqlalchemy import ForeignKey
+from sqlalchemy import ForeignKey, String
 from sqlalchemy.orm import Mapped, mapped_column
 
 from amt.models.base import Base
@@ -8,7 +8,7 @@ class Task(Base):
     __tablename__ = "task"
 
     id: Mapped[int] = mapped_column(primary_key=True)
-    title: Mapped[str]
+    title: Mapped[str] = mapped_column(String(length=1024))
     description: Mapped[str]
     sort_order: Mapped[float]
     status_id: Mapped[int | None] = mapped_column(default=None)

--- a/amt/repositories/tasks.py
+++ b/amt/repositories/tasks.py
@@ -76,6 +76,7 @@ class TasksRepository:
             self.session.add_all(tasks)
             self.session.commit()
         except Exception as e:
+            logger.exception("Could not store tasks")
             self.session.rollback()
             raise RepositoryError from e
 

--- a/amt/services/tasks.py
+++ b/amt/services/tasks.py
@@ -43,7 +43,9 @@ class TasksService:
             [
                 # TODO: (Christopher) The ticket does not specify what to do when question type is not an
                 # open questions, hence for now all titles will be set to task.question.
-                Task(title=task.question, description="", project_id=project.id, status_id=status, sort_order=idx)
+                Task(
+                    title=task.question[:1024], description="", project_id=project.id, status_id=status, sort_order=idx
+                )
                 for idx, task in enumerate(tasks)
             ]
         )


### PR DESCRIPTION
# Description

From instruments, the question is used for the title. For some questions, the title exceeded the 255 characters limit. The limit has been stretched to 1024 characters and better error prevention and logging has been added.

## Checklist

Please check all the boxes that apply to this pull request using "x":

- [X]  I have tested the changes locally and verified that they work as expected.
- [X]  I have followed the project's coding conventions and style guidelines.
- [X]  I have rebased my branch onto the latest commit of the main branch.
- [X]  I have squashed or reorganized my commits into logical units.
- [X]  I have read, understood and agree to the [Developer Certificate of Origin](../blob/main/DCO.md), which this project utilizes.
