### PR TITLE
Fix for reset button and reveal bug

### DIFF
--- a/amt/api/routes/projects.py
+++ b/amt/api/routes/projects.py
@@ -26,7 +26,7 @@ async def get_root(
 
     if request.state.htmx:
         return templates.TemplateResponse(
-            request, "projects/_list.html.j2", {"projects": projects, "next": next, "search": search}
+            request, "projects/_list.html.j2", {"projects": projects, "next": next, "search": search, "limit": limit}
         )
 
     return templates.TemplateResponse(

--- a/amt/site/templates/projects/_list.html.j2
+++ b/amt/site/templates/projects/_list.html.j2
@@ -1,6 +1,7 @@
 {% for project in projects %}
-<li><a href="/project/{{ project.id }}">{{ project.name }}</a></li>
+    {% if loop.last and projects|length == limit  %}
+        <li data-marker="last-element" hx-get="/projects/?skip={{ next }}&search={{ search }}" hx-swap="afterend" hx-trigger="revealed"><a href="/project/{{ project.id }}">{{ project.name }}</a></li>
+    {% else %}
+        <li><a href="/project/{{ project.id }}">{{ project.name }}</a></li>
+    {% endif %}
 {% endfor %}
-{% if projects|length > 0 %}
-<li hx-get="/projects/?skip={{ next }}&search={{ search }}" hx-swap="outerHTML" hx-trigger="revealed">More</li>
-{% endif %}

--- a/amt/site/templates/projects/index.html.j2
+++ b/amt/site/templates/projects/index.html.j2
@@ -19,7 +19,15 @@
         id="project-search-input"
     />
 </label>
-<input type="reset" value="X" style="position: relative; margin-left: -30px" />
+<input type="reset"
+       value="X"
+       style="position: relative; margin-left: -30px"
+       hx-trigger="click"
+       hx-get="/projects/?skip=0"
+       hx-target="#project-search-results"
+       hx-indicator=".htmx-indicator"
+       hx-swap="innerHTML"
+/>
 </form>
 
 <ul class="project-list" id="project-search-results">

--- a/tests/e2e/test_scroll_project.py
+++ b/tests/e2e/test_scroll_project.py
@@ -1,5 +1,5 @@
 import pytest
-from playwright.sync_api import Page
+from playwright.sync_api import Page, expect
 
 
 @pytest.mark.slow()
@@ -8,10 +8,12 @@ def test_e2e_scroll_projects(page: Page) -> None:
 
     project_links = page.locator(".project-list > li").count()
 
-    assert 90 <= project_links <= 101
+    assert project_links == 100
+
+    expect(page.locator('[data-marker="last-element"]')).to_be_visible()
 
     with page.expect_response("/projects/?skip=100&search=", timeout=3000) as response_info:
-        page.get_by_text("More").scroll_into_view_if_needed()
+        page.locator('[data-marker="last-element"]').scroll_into_view_if_needed()
 
     response = response_info.value
     assert response.status == 200


### PR DESCRIPTION
# Description

Fixes the reset button for clearing search results and only loads more elements when needed.

## Checklist

Please check all the boxes that apply to this pull request using "x":

- [X]  I have tested the changes locally and verified that they work as expected.
- [X]  I have followed the project's coding conventions and style guidelines.
- [X]  I have rebased my branch onto the latest commit of the main branch.
- [X]  I have squashed or reorganized my commits into logical units.
- [X]  I have read, understood and agree to the [Developer Certificate of Origin](../blob/main/DCO.md), which this project utilizes.
