### PR TITLE
Add notify to mattermost when a deployment is done on production

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -65,3 +65,16 @@ jobs:
           git push --force-with-lease
         env:
           GITHUB_TOKEN: ${{ secrets.GH_PAT }}
+
+  notifyMattermost:
+    runs-on: ubuntu-latest
+    if: ${{ success() && inputs.environment == 'production' }}
+    steps:
+      - uses: mattermost/action-mattermost-notify@master
+        with:
+          MATTERMOST_WEBHOOK_URL: ${{ secrets.MM_WEBHOOK_RELEASES }}
+          TEXT: |
+            :sparkles: A new version of AMT has been released on production by ${{ github.triggering_actor }} :sparkles:.
+
+            It will be available within a few minutes on https://amt.prd.apps.digilab.network/.
+          MATTERMOST_USERNAME: ${{ github.triggering_actor }}


### PR DESCRIPTION
# Description

One of the retro points a while ago was using a mattermost release channel for information about production releases. This change adds a mattermost notify when the deploy action is performed to production.

## Checklist

Please check all the boxes that apply to this pull request using "x":

-   [X] I have tested the changes locally and verified that they work as expected.
-   [X] I have followed the project's coding conventions and style guidelines.
-   [X] I have rebased my branch onto the latest commit of the main branch.
-   [X] I have squashed or reorganized my commits into logical units.
-   [X] I have read, understood and agree to the [Developer Certificate of Origin](../blob/main/DCO.md), which this project utilizes.
