### PR TITLE
Fix URL for decisiontree

### DIFF
--- a/amt/site/templates/projects/new.html.j2
+++ b/amt/site/templates/projects/new.html.j2
@@ -198,7 +198,7 @@
                 {% trans %}Copy results and close{% endtrans %}
             </button>
             <div id="app">
-                <script src="https://unpkg.com/ai-act-decision-tree@1.1.3/index.js"></script>
+                <script src="https://github.com/MinBZK/ai-act-decisiontree/releases/download/1.1.7/index.js"></script>
             </div>
         </p>
     </div>


### PR DESCRIPTION
# Description

Fixes the URL for the decisiontree which has been moved to GitHub.

## Checklist

Please check all the boxes that apply to this pull request using "x":

-   [X] I have tested the changes locally and verified that they work as expected.
-   [X] I have followed the project's coding conventions and style guidelines.
-   [X] I have rebased my branch onto the latest commit of the main branch.
-   [X] I have squashed or reorganized my commits into logical units.
-   [X] I have read, understood and agree to the [Developer Certificate of Origin](../blob/main/DCO.md), which this project utilizes.
