### PR TITLE
Make AI Act profile for Requirements a not required field

### DIFF
--- a/amt/schema/requirement.py
+++ b/amt/schema/requirement.py
@@ -63,7 +63,8 @@ class Requirement(RequirementBase):
     description: str
     schema_version: str
     links: list[str] = Field(default=[])
-    ai_act_profile: list[RequirementAiActProfile]
+    # TODO (Robbert): field below should be required but is made default for a task registry sync issue
+    ai_act_profile: list[RequirementAiActProfile] = Field(default=[])
     always_applicable: int = Field(
         ...,
         description="1 if requirements applies to every system, 0 if only for specific systems",


### PR DESCRIPTION
# Description

Makes the AI Act field not required so it can parse 'old format' requirements from the Task Registry.

## Checklist

Please check all the boxes that apply to this pull request using "x":

-   [x] I have tested the changes locally and verified that they work as expected.
-   [x] I have followed the project's coding conventions and style guidelines.
-   [x] I have rebased my branch onto the latest commit of the main branch.
-   [x] I have squashed or reorganized my commits into logical units.
-   [x] I have read, understood and agree to the [Developer Certificate of Origin](../blob/main/DCO.md), which this project utilizes.
