### PR TITLE
Breadcrumb and beslishulp fix

### DIFF
--- a/amt/locale/nl_NL/LC_MESSAGES/messages.po
+++ b/amt/locale/nl_NL/LC_MESSAGES/messages.po
@@ -640,7 +640,7 @@ msgstr "Er is één fout:"
 
 #: amt/site/templates/layouts/base.html.j2:1
 msgid "Algorithmic Management Toolkit (AMT)"
-msgstr "Algoritme Management Toolkit (AMT)"
+msgstr "Algoritme Management Toolkit"
 
 #: amt/site/templates/macros/table_row.html.j2:19
 msgid " ago"

--- a/amt/site/templates/algorithms/new.html.j2
+++ b/amt/site/templates/algorithms/new.html.j2
@@ -202,7 +202,7 @@
                 {% trans %}Copy results and close{% endtrans %}
             </button>
             <div id="app">
-                {#                <script src="https://github.com/MinBZK/ai-act-decisiontree/releases/download/1.1.7/index.js"></script>#}
+                <script src="https://github.com/MinBZK/ai-act-decisiontree/releases/download/1.1.7/index.js"></script>
             </div>
         </p>
     </div>

--- a/amt/site/templates/parts/header.html.j2
+++ b/amt/site/templates/parts/header.html.j2
@@ -195,9 +195,7 @@
                             <span class="utrecht-icon rvo-icon rvo-icon-delta-naar-rechts rvo-icon--xs rvo-icon--hemelblauw"
                                   role="img"
                                   aria-label="Delta naar rechts"></span>
-                            <span class="rvo-breadcrumb-current-page">
-                                {{ breadcrumb.display_text }}
-                            </span>
+                            <span class="rvo-breadcrumb-current-page">{{ breadcrumb.display_text }}</span>
                         </li>
                     {% else %}
                         <li class="rvo-breadcrumbs-item">

--- a/amt/site/templates/parts/header.html.j2
+++ b/amt/site/templates/parts/header.html.j2
@@ -192,10 +192,10 @@
                         </li>
                     {% elif loop.last %}
                         <li class="rvo-breadcrumbs-item">
+                            <span class="utrecht-icon rvo-icon rvo-icon-delta-naar-rechts rvo-icon--xs rvo-icon--hemelblauw"
+                                  role="img"
+                                  aria-label="Delta naar rechts"></span>
                             <span class="rvo-breadcrumb-current-page">
-                                <span class="utrecht-icon rvo-icon rvo-icon-delta-naar-rechts rvo-icon--xs rvo-icon--hemelblauw"
-                                      role="img"
-                                      aria-label="Delta naar rechts"></span>
                                 {{ breadcrumb.display_text }}
                             </span>
                         </li>


### PR DESCRIPTION
# Description

There is a span misplaced in the breadcrumbs which makes it looks wrong. This fixes that. 

It also fixes the link for the beslishulp.

## Checklist

Please check all the boxes that apply to this pull request using "x":

-   [X] I have tested the changes locally and verified that they work as expected.
-   [X] I have followed the project's coding conventions and style guidelines.
-   [X] I have rebased my branch onto the latest commit of the main branch.
-   [X] I have squashed or reorganized my commits into logical units.
-   [X] I have read, understood and agree to the [Developer Certificate of Origin](../blob/main/DCO.md), which this project utilizes.
