### PR TITLE
Fix: add system path so alembic can find the AMT package

### DIFF
--- a/alembic.ini
+++ b/alembic.ini
@@ -12,7 +12,7 @@ script_location = amt/migrations
 
 # sys.path path, will be prepended to sys.path if present.
 # defaults to the current working directory.
-# prepend_sys_path = .
+prepend_sys_path = .
 
 # timezone to use when rendering the date within the migration file
 # as well as the filename.


### PR DESCRIPTION
# Description

Fixes the alembic path so it can find the AMT package; the package is not build (anymore) due to changes we made because we now use poetry (2.0.0).

## Checklist

Please check all the boxes that apply to this pull request using "x":

- [X] I have tested the changes locally and verified that they work as expected.
- [X] I have followed the project's coding conventions and style guidelines.
- [X] I have rebased my branch onto the latest commit of the main branch.
- [X] I have squashed or reorganized my commits into logical units.
- [X] I have read, understood and agree to the [Developer Certificate of Origin](../blob/main/DCO.md), which this project utilizes.
