### PR TITLE
Add more editable fields, fix for the task registry api client caching 

### DIFF
--- a/amt/clients/clients.py
+++ b/amt/clients/clients.py
@@ -29,7 +29,10 @@ class APIClient:
         self.client = httpx.AsyncClient(timeout=timeout, transport=transport)
 
     async def _make_request(self, endpoint: str, params: dict[str, Any] | None = None) -> dict[str, Any]:
-        response = await self.client.get(f"{self.base_url}/{endpoint}", params=params)
+        # we use 'Connection: close' for this reason https://github.com/encode/httpx/discussions/2959
+        response = await self.client.get(
+            f"{self.base_url}/{endpoint}", params=params, headers=[("Connection", "close")]
+        )
         if response.status_code != 200:
             raise AMTNotFound()
         return response.json()

--- a/amt/clients/clients.py
+++ b/amt/clients/clients.py
@@ -55,8 +55,9 @@ class TaskRegistryAPIClient(APIClient):
         return response_data
 
 
+task_registry_api_client = TaskRegistryAPIClient()
+
+
 @alru_cache(maxsize=0 if "pytest" in sys.modules else 1000)
-async def get_task_by_urn(
-    client: TaskRegistryAPIClient, task_type: TaskType, urn: str, version: str = "latest"
-) -> dict[str, Any]:
-    return await client.get_task_by_urn(task_type, urn, version)
+async def get_task_by_urn(task_type: TaskType, urn: str, version: str = "latest") -> dict[str, Any]:
+    return await task_registry_api_client.get_task_by_urn(task_type, urn, version)

--- a/amt/core/exception_handlers.py
+++ b/amt/core/exception_handlers.py
@@ -79,7 +79,9 @@ async def general_exception_handler(request: Request, exc: Exception) -> HTMLRes
             request, template_name, {"message": message}, status_code=status_code, headers=response_headers
         )
     except Exception:
-        logger.exception("Can not display error template")
+        logger.warning(
+            "Can not display error template " + template_name + " as it does not exist, using fallback template"
+        )
         response = templates.TemplateResponse(
             request,
             fallback_template_name,

--- a/amt/repositories/task_registry.py
+++ b/amt/repositories/task_registry.py
@@ -48,7 +48,7 @@ class TaskRegistryRepository:
         Fetches tasks given a list of URN's.
         If an URN is not valid, it is ignored.
         """
-        get_tasks = [get_task_by_urn(self.client, task_type, urn) for urn in urns]
+        get_tasks = [get_task_by_urn(task_type, urn) for urn in urns]
         results = await asyncio.gather(*get_tasks, return_exceptions=True)
 
         tasks: list[dict[str, Any]] = []

--- a/amt/services/instruments.py
+++ b/amt/services/instruments.py
@@ -1,7 +1,7 @@
 import logging
 from collections.abc import Sequence
 
-from amt.clients.clients import TaskRegistryAPIClient, TaskType
+from amt.clients.clients import TaskType, task_registry_api_client
 from amt.repositories.task_registry import TaskRegistryRepository
 from amt.schema.instrument import Instrument
 
@@ -24,6 +24,5 @@ class InstrumentsService:
 
 
 def create_instrument_service() -> InstrumentsService:
-    client = TaskRegistryAPIClient()
-    repository = TaskRegistryRepository(client)
+    repository = TaskRegistryRepository(task_registry_api_client)
     return InstrumentsService(repository)

--- a/amt/services/measures.py
+++ b/amt/services/measures.py
@@ -1,7 +1,7 @@
 import logging
 from collections.abc import Sequence
 
-from amt.clients.clients import TaskRegistryAPIClient, TaskType
+from amt.clients.clients import TaskType, task_registry_api_client
 from amt.repositories.task_registry import TaskRegistryRepository
 from amt.schema.measure import Measure
 
@@ -24,6 +24,5 @@ class MeasuresService:
 
 
 def create_measures_service() -> MeasuresService:
-    client = TaskRegistryAPIClient()
-    repository = TaskRegistryRepository(client)
+    repository = TaskRegistryRepository(task_registry_api_client)
     return MeasuresService(repository)

--- a/amt/services/requirements.py
+++ b/amt/services/requirements.py
@@ -1,7 +1,7 @@
 import logging
 from collections.abc import Sequence
 
-from amt.clients.clients import TaskRegistryAPIClient, TaskType
+from amt.clients.clients import TaskType, task_registry_api_client
 from amt.repositories.task_registry import TaskRegistryRepository
 from amt.schema.requirement import Requirement
 
@@ -24,6 +24,5 @@ class RequirementsService:
 
 
 def create_requirements_service() -> RequirementsService:
-    client = TaskRegistryAPIClient()
-    repository = TaskRegistryRepository(client)
+    repository = TaskRegistryRepository(task_registry_api_client)
     return RequirementsService(repository)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -139,7 +139,7 @@ filterwarnings = [
 ]
 log_cli = true
 log_cli_level = "INFO"
-faulthandler_timeout = 40
+faulthandler_timeout = 60
 markers = [
    "slow: marks tests as slow",
    "enable_auth: marks tests that require authentication"

--- a/tests/api/routes/test_algorithm.py
+++ b/tests/api/routes/test_algorithm.py
@@ -584,6 +584,7 @@ async def test_update_measure_value(
 
 
 @pytest.mark.asyncio
+@amt_vcr.use_cassette("tests/fixtures/vcr_cassettes/test_update_measure_value_with_people.yml")  # type: ignore
 async def test_update_measure_value_with_people(
     minio_mock: MockMinioClient, client: AsyncClient, mocker: MockFixture, db: DatabaseTestUtils
 ) -> None:

--- a/tests/clients/test_clients.py
+++ b/tests/clients/test_clients.py
@@ -1,7 +1,7 @@
 import json
 
 import pytest
-from amt.clients.clients import TaskRegistryAPIClient, TaskType
+from amt.clients.clients import TaskType, task_registry_api_client
 from amt.core.exceptions import AMTNotFound
 from amt.schema.github import RepositoryContent
 from pytest_httpx import HTTPXMock
@@ -10,7 +10,6 @@ from tests.constants import TASK_REGISTRY_CONTENT_PAYLOAD, TASK_REGISTRY_LIST_PA
 
 @pytest.mark.asyncio
 async def test_task_registry_api_client_get_instrument_list(httpx_mock: HTTPXMock):
-    task_registry_api_client = TaskRegistryAPIClient()
     httpx_mock.add_response(
         url="https://task-registry.apps.digilab.network/instruments/", content=TASK_REGISTRY_LIST_PAYLOAD.encode()
     )
@@ -22,7 +21,6 @@ async def test_task_registry_api_client_get_instrument_list(httpx_mock: HTTPXMoc
 
 @pytest.mark.asyncio
 async def test_task_registry_api_client_get_instrument_list_not_succesfull(httpx_mock: HTTPXMock):
-    task_registry_api_client = TaskRegistryAPIClient()
     httpx_mock.add_response(status_code=408, url="https://task-registry.apps.digilab.network/instruments/")
 
     # then
@@ -33,7 +31,6 @@ async def test_task_registry_api_client_get_instrument_list_not_succesfull(httpx
 @pytest.mark.asyncio
 async def test_task_registry_api_client_get_instrument(httpx_mock: HTTPXMock):
     # given
-    task_registry_api_client = TaskRegistryAPIClient()
     httpx_mock.add_response(
         url="https://task-registry.apps.digilab.network/instruments/urn/urn:nl:aivt:tr:iama:1.0?version=latest",
         content=TASK_REGISTRY_CONTENT_PAYLOAD.encode(),
@@ -49,7 +46,6 @@ async def test_task_registry_api_client_get_instrument(httpx_mock: HTTPXMock):
 
 @pytest.mark.asyncio
 async def test_task_registry_api_client_get_instrument_not_succesfull(httpx_mock: HTTPXMock):
-    task_registry_api_client = TaskRegistryAPIClient()
     httpx_mock.add_response(
         status_code=408,
         url="https://task-registry.apps.digilab.network/instruments/urn/urn:nl:aivt:tr:iama:1.0?version=latest",

--- a/tests/e2e/test_create_algorithm.py
+++ b/tests/e2e/test_create_algorithm.py
@@ -34,8 +34,8 @@ def test_e2e_create_algorithm(page: Page) -> None:
 
     button = page.locator("#button-new-algorithm-create")
     button.click()
-    page.wait_for_timeout(30000)
-    expect(page.get_by_text("My new algorithm").first).to_be_visible(timeout=10000)
+
+    expect(page.get_by_text("My new algorithm").first).to_be_visible(timeout=90000)
 
 
 @pytest.mark.slow

--- a/tests/fixtures/vcr_cassettes/test_update_measure_value_with_people.yml
+++ b/tests/fixtures/vcr_cassettes/test_update_measure_value_with_people.yml
@@ -1,0 +1,272 @@
+interactions:
+  - request:
+      body: ""
+      headers:
+        accept:
+          - "*/*"
+        accept-encoding:
+          - gzip, deflate
+        connection:
+          - close
+        host:
+          - task-registry.apps.digilab.network
+        user-agent:
+          - python-httpx/0.28.1
+      method: GET
+      uri: https://task-registry.apps.digilab.network/measures/urn/urn:nl:ak:mtr:dat-01?version=latest
+    response:
+      body:
+        string:
+          "{\"systemcard_path\":\".systemcard.requirements[]\",\"schema_version\":\"1.1.0\",\"name\":\"Controleer
+          de datakwaliteit\",\"description\":\"Stel vast of de gebruikte data van voldoende
+          kwaliteit is voor de beoogde toepassing.\\n\",\"explanation\":\"- Stel functionele
+          eisen voor de datakwaliteit vast en [analyseer structureel of er aan deze
+          eisen wordt voldaan](https://minbzk.github.io/Algoritmekader/voldoen-aan-wetten-en-regels/maatregelen/7-mon-05-evalueer-bij-veranderingen-in-data/index.html).
+          \\n\\n- De kwaliteit van de data die als input voor het algoritme wordt gebruikt
+          is bepalend voor de uitkomsten van het algoritme. Hier wordt soms ook naar
+          gerefereerd als *garbage in = garbage out*. \\n- Een vraag die gesteld dient
+          te worden: beschrijft de data het fenomeen dat onderzocht dient te worden?
+          \\n- Het [Raamwerk gegevenskwaliteit](https://www.noraonline.nl/wiki/Raamwerk_gegevenskwaliteit)
+          bevat een breed toepasbare set van kwaliteitsdimensies:\\n\\n    - juistheid\\n
+          \   - compleetheid\\n    - validiteit\\n    - consistentie\\n    - actualiteit\\n
+          \   - precisie\\n    - plausibiliteit\\n    - traceerbaarheid\\n    - begrijpelijkheid\\n\\n
+          \   Deze dimensies zijn aangevuld met [kwaliteitsattributen](https://www.noraonline.nl/wiki/Raamwerk_gegevenskwaliteit/Kwaliteitsattributen)
+          welke gebruikt kunnen worden om de verschillende dimensies meetbaar te maken.
+          \\n\\n- De vraag of de data kwaliteit voldoende is, hangt sterk samen met
+          de vraag of er bias in de onderliggende data zit. Analyseer daarom ook welke
+          bias en aannames er besloten zijn in de onderliggende data. Denk hierbij onder
+          andere aan de volgende vormen van bias:\\n\\n    - [historische bias](../../onderwerpen/bias-en-non-discriminatie.md#herken-bias)\\n
+          \   - [meetbias](../../onderwerpen/bias-en-non-discriminatie.md#herken-bias)\\n
+          \   - [representatie bias](../../onderwerpen/bias-en-non-discriminatie.md#herken-bias)\\n\\n-
+          Zorg dat je data [vindbaar, toegankelijk, interoperabel en herbruikbaar (FAIR)](https://minbzk.github.io/Algoritmekader/voldoen-aan-wetten-en-regels/maatregelen/3-dat-02-fair-data/index.html)
+          is.\\n\\n\\n!!! note \\\"Let op!\\\"\\n\\n    Wanneer je een algoritme inkoopt
+          en de ontwikkeling van het algoritme uitbesteedt aan een derde partij, houdt
+          er dan dan rekening mee dat data traceerbaar en reproduceerbaar moet zijn.
+          Maak hier heldere afspraken over met de aanbieder. \\n\\n- Door onjuiste beslissingen
+          van gegevens kunnen verkeerde beslissingen genomen worden. \\n- Het model
+          cre\xEBert onwenselijke systematische afwijking voor specifieke personen,
+          groepen of andere eenheden. Dit kan leiden tot ongelijke behandeling en discriminerende
+          effecten met eventuele schade voor betrokkenen. \\n\",\"urn\":\"urn:nl:ak:mtr:dat-01\",\"language\":\"nl\",\"owners\":[{\"organization\":\"Algoritmekader\",\"name\":\"\",\"email\":\"\",\"role\":\"\"}],\"date\":\"\",\"url\":\"https://minbzk.github.io/Algoritmekader/voldoen-aan-wetten-en-regels/maatregelen/3-dat-01-datakwaliteit/index.html\",\"subject\":[\"data\"],\"suggested_roles\":[\"ontwikkelaar\"],\"lifecycle\":[\"dataverkenning-en-datapreparatie\"],\"links\":[\"urn:nl:ak:ver:avg-05\",\"urn:nl:ak:ver:aia-05\"],\"template\":{\"requirement\":\"$REQUIREMENT\",\"remarks\":\"$REMARKS\",\"status\":\"$STATUS\",\"timestamp\":\"$TIMESTAMP\",\"authors\":[{\"name\":\"$AUTHOR.NAME\",\"email\":\"$AUTHOR.EMAIL\",\"role\":\"$AUTHOR.ROLE\"}]}}"
+      headers:
+        Connection:
+          - close
+        Content-Length:
+          - "3253"
+        Content-Type:
+          - application/json
+        Date:
+          - Wed, 15 Jan 2025 14:31:34 GMT
+        Strict-Transport-Security:
+          - max-age=31536000; includeSubDomains
+      status:
+        code: 200
+        message: OK
+  - request:
+      body: ""
+      headers:
+        accept:
+          - "*/*"
+        accept-encoding:
+          - gzip, deflate
+        connection:
+          - close
+        host:
+          - task-registry.apps.digilab.network
+        user-agent:
+          - python-httpx/0.28.1
+      method: GET
+      uri: https://task-registry.apps.digilab.network/requirements/urn/urn:nl:ak:ver:avg-05?version=latest
+    response:
+      body:
+        string:
+          '{"systemcard_path":".systemcard.requirements[]","schema_version":"1.1.0","name":"Persoonsgegevens
+          zijn juist en actueel.","description":"\nPersoonsgegevens zijn juist en actueel.\n","explanation":"De
+          te verwerken persoonsgegevens moeten nauwkeurig, juist en zo nodig actueel
+          zijn.\nDit betekent dat alle maatregelen moeten worden genomen om ervoor te
+          zorgen dat onjuiste persoonsgegevens worden gerectificeerd of gewist.\n\nDat
+          kan betekenen dat persoonsgegevens moeten worden geactualiseerd of verbeterd.
+          In de context van algoritmes is het van belang dat ook daar wordt onderzocht
+          welke maatregelen nodig zijn om die [juistheid](https://minbzk.github.io/Algoritmekader/voldoen-aan-wetten-en-regels/maatregelen/2-owp-11-gebruikte-data/index.html)
+          toe te passen.\n\n\nAls er geen rekening wordt gehouden met de juistheid,
+          nauwkeurigheid en volledigheid van persoonsgegevens, kunnen kwaliteit en integriteit
+          van data niet voldoende worden gewaarborgd.\n","urn":"urn:nl:ak:ver:avg-05","language":"nl","owners":[{"organization":"Algoritmekader","name":"","email":"","role":""}],"date":"","url":"https://minbzk.github.io/Algoritmekader/voldoen-aan-wetten-en-regels/vereisten/avg-05-juistheid-en-actualiteit-van-persoonsgegevens/index.html","subject":["privacy-en-gegevensbescherming"],"lifecycle":["dataverkenning-en-datapreparatie"],"links":["urn:nl:ak:mtr:owp-15","urn:nl:ak:mtr:owp-16","urn:nl:ak:mtr:owp-22","urn:nl:ak:mtr:owp-24","urn:nl:ak:mtr:owp-28","urn:nl:ak:mtr:dat-01","urn:nl:ak:mtr:mon-05"],"ai_act_profile":[{"type":[],"open_source":[],"risk_group":[],"systemic_risk":[],"transparency_obligations":[],"role":[],"conformity_assessment_body":[]}],"always_applicable":1,"template":{"requirement":"$REQUIREMENT","remarks":"$REMARKS","status":"$STATUS","timestamp":"$TIMESTAMP","authors":[{"name":"$AUTHOR.NAME","email":"$AUTHOR.EMAIL","role":"$AUTHOR.ROLE"}]}}'
+      headers:
+        Connection:
+          - close
+        Content-Length:
+          - "1867"
+        Content-Type:
+          - application/json
+        Date:
+          - Wed, 15 Jan 2025 14:31:34 GMT
+        Strict-Transport-Security:
+          - max-age=31536000; includeSubDomains
+      status:
+        code: 200
+        message: OK
+  - request:
+      body: ""
+      headers:
+        accept:
+          - "*/*"
+        accept-encoding:
+          - gzip, deflate
+        connection:
+          - close
+        host:
+          - task-registry.apps.digilab.network
+        user-agent:
+          - python-httpx/0.28.1
+      method: GET
+      uri: https://task-registry.apps.digilab.network/requirements/urn/urn:nl:ak:ver:aia-05?version=latest
+    response:
+      body:
+        string:
+          '{"systemcard_path":".systemcard.requirements[]","schema_version":"1.1.0","name":"Datasets
+          voor hoog-risico-AI-systemen voldoen aan kwaliteitscriteria","description":"\nAI-systemen
+          met een hoog risico die technieken gebruiken die het trainen van AI-modellen
+          met data omvatten, worden ontwikkeld op basis van datasets voor training,
+          validatie en tests die voldoen aan de kwaliteitscriteria telkens wanneer dergelijke
+          datasets worden gebruikt.\n","explanation":"AI-systemen met een hoog risico
+          die data gebruiken voor het trainen van AI-modellen, moeten gebaseerd zijn
+          op datasets die voldoen aan specifieke [kwaliteitscriteria](https://minbzk.github.io/Algoritmekader/voldoen-aan-wetten-en-regels/maatregelen/3-dat-01-datakwaliteit/index.html).
+          \n\nDeze criteria zorgen ervoor dat de data geschikt zijn voor [training,
+          validatie en tests](https://minbzk.github.io/Algoritmekader/voldoen-aan-wetten-en-regels/maatregelen/3-dat-07-training-validatie-en-testdata/index.html),
+          wat de betrouwbaarheid en nauwkeurigheid van het AI-systeem waarborgt. De
+          kwaliteitscriteria zijn te vinden in leden 2 t/m 5 van artikel 10 van de AI-verordening.
+          Bijvoorbeeld datasets moeten aan praktijken voor databeheer voldoen en moeten
+          relevant, representatief, accuraat en volledig zijn.\n\nDeze vereiste houdt
+          in dat de gebruikte datasets onder meer moeten voldoen aan:\n\n- datasets
+          voor training, validatie en tests worden onderworpen aan praktijken op het
+          gebied van databeheer die stroken met het beoogde doel van het AI-systeem
+          met een hoog risico. Dit heeft in het bijzonder betrekking op relevante ontwerpkeuzes,
+          processen voor dataverzameling, verwerkingsactiviteiten voor datavoorbereiding,
+          het opstellen van aannames met name betrekking tot de informatie die de data
+          moeten meten en vertegenwoordigen, beschikbaarheid, kwantiteit en geschiktheid
+          van de datasets en een beoordeling op mogelijke vooringenomenheid en passende
+          maatregelen om deze vooringenomenheid op te sporen, te voorkomen en te beperken.
+          \n- datasets voor training, validatie en tests zijn relevant, voldoende representatief
+          en zoveel mogelijk foutenvrij en volledig met het oog op het beoogde doel.\n-
+          Er wordt rekening gehouden met de eigenschappen of elementen die specifiek
+          zijn voor een bepaalde geografische, contextuele, functionele of gedragsomgeving
+          waarin het AI-systeem wordt gebruikt.\n","urn":"urn:nl:ak:ver:aia-05","language":"nl","owners":[{"organization":"Algoritmekader","name":"","email":"","role":""}],"date":"","url":"https://minbzk.github.io/Algoritmekader/voldoen-aan-wetten-en-regels/vereisten/aia-05-data-kwaliteitscriteria/index.html","subject":["data"],"lifecycle":["dataverkenning-en-datapreparatie","verificatie-en-validatie"],"links":["urn:nl:ak:mtr:owp-11","urn:nl:ak:mtr:owp-15","urn:nl:ak:mtr:owp-16","urn:nl:ak:mtr:owp-21","urn:nl:ak:mtr:owp-22","urn:nl:ak:mtr:owp-24","urn:nl:ak:mtr:owp-28","urn:nl:ak:mtr:owp-29","urn:nl:ak:mtr:owp-30","urn:nl:ak:mtr:owp-32","urn:nl:ak:mtr:owp-35","urn:nl:ak:mtr:dat-01","urn:nl:ak:mtr:dat-08","urn:nl:ak:mtr:ver-05","urn:nl:ak:mtr:mon-05"],"ai_act_profile":[{"type":["AI-systeem","AI-systeem
+          voor algemene doeleinden"],"open_source":[],"risk_group":["hoog-risico AI"],"systemic_risk":[],"transparency_obligations":[],"role":["aanbieder"],"conformity_assessment_body":[]}],"always_applicable":0,"template":{"requirement":"$REQUIREMENT","remarks":"$REMARKS","status":"$STATUS","timestamp":"$TIMESTAMP","authors":[{"name":"$AUTHOR.NAME","email":"$AUTHOR.EMAIL","role":"$AUTHOR.ROLE"}]}}'
+      headers:
+        Connection:
+          - close
+        Content-Length:
+          - "3508"
+        Content-Type:
+          - application/json
+        Date:
+          - Wed, 15 Jan 2025 14:31:34 GMT
+        Strict-Transport-Security:
+          - max-age=31536000; includeSubDomains
+      status:
+        code: 200
+        message: OK
+  - request:
+      body: ""
+      headers:
+        accept:
+          - "*/*"
+        accept-encoding:
+          - gzip, deflate
+        connection:
+          - close
+        host:
+          - task-registry.apps.digilab.network
+        user-agent:
+          - python-httpx/0.28.1
+      method: GET
+      uri: https://task-registry.apps.digilab.network/requirements/urn/urn:nl:ak:ver:avg-05?version=latest
+    response:
+      body:
+        string:
+          '{"systemcard_path":".systemcard.requirements[]","schema_version":"1.1.0","name":"Persoonsgegevens
+          zijn juist en actueel.","description":"\nPersoonsgegevens zijn juist en actueel.\n","explanation":"De
+          te verwerken persoonsgegevens moeten nauwkeurig, juist en zo nodig actueel
+          zijn.\nDit betekent dat alle maatregelen moeten worden genomen om ervoor te
+          zorgen dat onjuiste persoonsgegevens worden gerectificeerd of gewist.\n\nDat
+          kan betekenen dat persoonsgegevens moeten worden geactualiseerd of verbeterd.
+          In de context van algoritmes is het van belang dat ook daar wordt onderzocht
+          welke maatregelen nodig zijn om die [juistheid](https://minbzk.github.io/Algoritmekader/voldoen-aan-wetten-en-regels/maatregelen/2-owp-11-gebruikte-data/index.html)
+          toe te passen.\n\n\nAls er geen rekening wordt gehouden met de juistheid,
+          nauwkeurigheid en volledigheid van persoonsgegevens, kunnen kwaliteit en integriteit
+          van data niet voldoende worden gewaarborgd.\n","urn":"urn:nl:ak:ver:avg-05","language":"nl","owners":[{"organization":"Algoritmekader","name":"","email":"","role":""}],"date":"","url":"https://minbzk.github.io/Algoritmekader/voldoen-aan-wetten-en-regels/vereisten/avg-05-juistheid-en-actualiteit-van-persoonsgegevens/index.html","subject":["privacy-en-gegevensbescherming"],"lifecycle":["dataverkenning-en-datapreparatie"],"links":["urn:nl:ak:mtr:owp-15","urn:nl:ak:mtr:owp-16","urn:nl:ak:mtr:owp-22","urn:nl:ak:mtr:owp-24","urn:nl:ak:mtr:owp-28","urn:nl:ak:mtr:dat-01","urn:nl:ak:mtr:mon-05"],"ai_act_profile":[{"type":[],"open_source":[],"risk_group":[],"systemic_risk":[],"transparency_obligations":[],"role":[],"conformity_assessment_body":[]}],"always_applicable":1,"template":{"requirement":"$REQUIREMENT","remarks":"$REMARKS","status":"$STATUS","timestamp":"$TIMESTAMP","authors":[{"name":"$AUTHOR.NAME","email":"$AUTHOR.EMAIL","role":"$AUTHOR.ROLE"}]}}'
+      headers:
+        Connection:
+          - close
+        Content-Length:
+          - "1867"
+        Content-Type:
+          - application/json
+        Date:
+          - Wed, 15 Jan 2025 14:31:34 GMT
+        Strict-Transport-Security:
+          - max-age=31536000; includeSubDomains
+      status:
+        code: 200
+        message: OK
+  - request:
+      body: ""
+      headers:
+        accept:
+          - "*/*"
+        accept-encoding:
+          - gzip, deflate
+        connection:
+          - close
+        host:
+          - task-registry.apps.digilab.network
+        user-agent:
+          - python-httpx/0.28.1
+      method: GET
+      uri: https://task-registry.apps.digilab.network/requirements/urn/urn:nl:ak:ver:aia-05?version=latest
+    response:
+      body:
+        string:
+          '{"systemcard_path":".systemcard.requirements[]","schema_version":"1.1.0","name":"Datasets
+          voor hoog-risico-AI-systemen voldoen aan kwaliteitscriteria","description":"\nAI-systemen
+          met een hoog risico die technieken gebruiken die het trainen van AI-modellen
+          met data omvatten, worden ontwikkeld op basis van datasets voor training,
+          validatie en tests die voldoen aan de kwaliteitscriteria telkens wanneer dergelijke
+          datasets worden gebruikt.\n","explanation":"AI-systemen met een hoog risico
+          die data gebruiken voor het trainen van AI-modellen, moeten gebaseerd zijn
+          op datasets die voldoen aan specifieke [kwaliteitscriteria](https://minbzk.github.io/Algoritmekader/voldoen-aan-wetten-en-regels/maatregelen/3-dat-01-datakwaliteit/index.html).
+          \n\nDeze criteria zorgen ervoor dat de data geschikt zijn voor [training,
+          validatie en tests](https://minbzk.github.io/Algoritmekader/voldoen-aan-wetten-en-regels/maatregelen/3-dat-07-training-validatie-en-testdata/index.html),
+          wat de betrouwbaarheid en nauwkeurigheid van het AI-systeem waarborgt. De
+          kwaliteitscriteria zijn te vinden in leden 2 t/m 5 van artikel 10 van de AI-verordening.
+          Bijvoorbeeld datasets moeten aan praktijken voor databeheer voldoen en moeten
+          relevant, representatief, accuraat en volledig zijn.\n\nDeze vereiste houdt
+          in dat de gebruikte datasets onder meer moeten voldoen aan:\n\n- datasets
+          voor training, validatie en tests worden onderworpen aan praktijken op het
+          gebied van databeheer die stroken met het beoogde doel van het AI-systeem
+          met een hoog risico. Dit heeft in het bijzonder betrekking op relevante ontwerpkeuzes,
+          processen voor dataverzameling, verwerkingsactiviteiten voor datavoorbereiding,
+          het opstellen van aannames met name betrekking tot de informatie die de data
+          moeten meten en vertegenwoordigen, beschikbaarheid, kwantiteit en geschiktheid
+          van de datasets en een beoordeling op mogelijke vooringenomenheid en passende
+          maatregelen om deze vooringenomenheid op te sporen, te voorkomen en te beperken.
+          \n- datasets voor training, validatie en tests zijn relevant, voldoende representatief
+          en zoveel mogelijk foutenvrij en volledig met het oog op het beoogde doel.\n-
+          Er wordt rekening gehouden met de eigenschappen of elementen die specifiek
+          zijn voor een bepaalde geografische, contextuele, functionele of gedragsomgeving
+          waarin het AI-systeem wordt gebruikt.\n","urn":"urn:nl:ak:ver:aia-05","language":"nl","owners":[{"organization":"Algoritmekader","name":"","email":"","role":""}],"date":"","url":"https://minbzk.github.io/Algoritmekader/voldoen-aan-wetten-en-regels/vereisten/aia-05-data-kwaliteitscriteria/index.html","subject":["data"],"lifecycle":["dataverkenning-en-datapreparatie","verificatie-en-validatie"],"links":["urn:nl:ak:mtr:owp-11","urn:nl:ak:mtr:owp-15","urn:nl:ak:mtr:owp-16","urn:nl:ak:mtr:owp-21","urn:nl:ak:mtr:owp-22","urn:nl:ak:mtr:owp-24","urn:nl:ak:mtr:owp-28","urn:nl:ak:mtr:owp-29","urn:nl:ak:mtr:owp-30","urn:nl:ak:mtr:owp-32","urn:nl:ak:mtr:owp-35","urn:nl:ak:mtr:dat-01","urn:nl:ak:mtr:dat-08","urn:nl:ak:mtr:ver-05","urn:nl:ak:mtr:mon-05"],"ai_act_profile":[{"type":["AI-systeem","AI-systeem
+          voor algemene doeleinden"],"open_source":[],"risk_group":["hoog-risico AI"],"systemic_risk":[],"transparency_obligations":[],"role":["aanbieder"],"conformity_assessment_body":[]}],"always_applicable":0,"template":{"requirement":"$REQUIREMENT","remarks":"$REMARKS","status":"$STATUS","timestamp":"$TIMESTAMP","authors":[{"name":"$AUTHOR.NAME","email":"$AUTHOR.EMAIL","role":"$AUTHOR.ROLE"}]}}'
+      headers:
+        Connection:
+          - close
+        Content-Length:
+          - "3508"
+        Content-Type:
+          - application/json
+        Date:
+          - Wed, 15 Jan 2025 14:31:34 GMT
+        Strict-Transport-Security:
+          - max-age=31536000; includeSubDomains
+      status:
+        code: 200
+        message: OK
+version: 1

--- a/tests/repositories/test_task_registry.py
+++ b/tests/repositories/test_task_registry.py
@@ -1,5 +1,5 @@
 import pytest
-from amt.clients.clients import TaskRegistryAPIClient, TaskType
+from amt.clients.clients import TaskType, task_registry_api_client
 from amt.core.exceptions import AMTInstrumentError
 from amt.repositories.task_registry import TaskRegistryRepository
 from pytest_httpx import HTTPXMock
@@ -10,8 +10,7 @@ from tests.conftest import amt_vcr
 @pytest.mark.asyncio
 async def test_fetch_tasks_all():
     # given
-    client = TaskRegistryAPIClient()
-    repository = TaskRegistryRepository(client)
+    repository = TaskRegistryRepository(task_registry_api_client)
 
     # when
     instrument_result = await repository.fetch_tasks(TaskType.INSTRUMENTS)
@@ -28,8 +27,7 @@ async def test_fetch_tasks_all():
 @pytest.mark.asyncio
 async def test_fetch_task_with_urn():
     # given
-    client = TaskRegistryAPIClient()
-    repository = TaskRegistryRepository(client)
+    repository = TaskRegistryRepository(task_registry_api_client)
     instrument_urn = "urn:nl:aivt:tr:iama:1.0"
     requirement_urn = "urn:nl:ak:ver:aia-08"
     measure_urn = "urn:nl:ak:mtr:dat-02"
@@ -57,8 +55,7 @@ async def test_fetch_task_with_urn():
 @pytest.mark.asyncio
 async def test_fetch_task_with_urns():
     # given
-    client = TaskRegistryAPIClient()
-    repository = TaskRegistryRepository(client)
+    repository = TaskRegistryRepository(task_registry_api_client)
     urns = ["urn:nl:aivt:tr:iama:1.0", "urn:nl:aivt:tr:aiia:1.0"]
 
     # when
@@ -76,8 +73,7 @@ async def test_fetch_task_with_urns():
 @pytest.mark.asyncio
 async def test_fetch_task_with_invalid_urn():
     # given
-    client = TaskRegistryAPIClient()
-    repository = TaskRegistryRepository(client)
+    repository = TaskRegistryRepository(task_registry_api_client)
     urn = "invalid"
 
     # when
@@ -91,8 +87,7 @@ async def test_fetch_task_with_invalid_urn():
 @pytest.mark.asyncio
 async def test_fetch_task_with_valid_and_invalid_urn():
     # given
-    client = TaskRegistryAPIClient()
-    repository = TaskRegistryRepository(client)
+    repository = TaskRegistryRepository(task_registry_api_client)
     urns = ["urn:nl:aivt:tr:iama:1.0", "invalid"]
 
     # when
@@ -107,8 +102,7 @@ async def test_fetch_task_with_valid_and_invalid_urn():
 @pytest.mark.asyncio
 async def test_fetch_tasks_invalid_response(httpx_mock: HTTPXMock):
     # given
-    client = TaskRegistryAPIClient()
-    repository = TaskRegistryRepository(client)
+    repository = TaskRegistryRepository(task_registry_api_client)
     urn = "urn:nl:aivt:tr:td:1.0"
 
     httpx_mock.add_response(


### PR DESCRIPTION
Fixes a bug where the alru cache did not work due to the TaskRegistryClient being a parameter. We now use 1 global TaskRegistryClient.

## Checklist

Please check all the boxes that apply to this pull request using "x":

- [X] I have tested the changes locally and verified that they work as expected.
- [X] I have followed the project's coding conventions and style guidelines.
- [X] I have rebased my branch onto the latest commit of the main branch.
- [X] I have squashed or reorganized my commits into logical units.
- [X] I have read, understood and agree to the [Developer Certificate of Origin](../blob/main/DCO.md), which this project utilizes.
