### PR TITLE
Make logging to file optional and False by default

### DIFF
--- a/USAGE.md
+++ b/USAGE.md
@@ -103,6 +103,8 @@ AMT uses environmental options that you can set when running the application.
 | ENVIRONMENT             | local or production                                                   | local                       |
 | LOGGING_LEVEL           | default Logging level "DEBUG", "INFO", "WARNING", "ERROR", "CRITICAL" | INFO                        |
 | LOGGING_CONFIG          | json dict of extra logging config                                     |                             |
+| LOG_TO_FILE             | enable logging to file (amt.log)                                      | False                       |
+| LOGFILE_LOCATION        | directory path where log file should be written                       | OS temp directory           |
 | DEBUG                   | enable debugging with trace dumps                                     | False                       |
 | AUTO_CREATE_SCHEMA      | Auto create schema, not recommended for production                    | False                       |
 | CARD_DIR                | Directory to Card storage                                             | /tmp/                       |

--- a/amt/core/config.py
+++ b/amt/core/config.py
@@ -1,5 +1,6 @@
 import logging
 import secrets
+import tempfile
 from pathlib import Path
 from typing import Any, TypeVar
 
@@ -31,6 +32,8 @@ class Settings(BaseSettings):
 
     LOGGING_LEVEL: LoggingLevelType = "INFO"
     LOGGING_CONFIG: dict[str, Any] | None = None
+    LOG_TO_FILE: bool = False
+    LOGFILE_LOCATION: Path = Path(tempfile.gettempdir())
 
     DEBUG: bool = False
     AUTO_CREATE_SCHEMA: bool = False

--- a/amt/core/log.py
+++ b/amt/core/log.py
@@ -1,6 +1,7 @@
 import copy
 import logging
 import logging.config
+from pathlib import Path
 from typing import Any
 
 from amt.core.types import LoggingLevelType
@@ -21,24 +22,39 @@ LOGGING_CONFIG = {
     },
     "handlers": {
         "console": {"formatter": "generic", "class": "logging.StreamHandler", "stream": "ext://sys.stdout"},
-        "file": {
-            "formatter": "generic",
-            "()": "logging.handlers.RotatingFileHandler",
-            "filename": "amt.log",
-            "maxBytes": LOGGING_SIZE,
-            "backupCount": LOGGING_BACKUP_COUNT,
-        },
     },
     "loggers": {
-        "": {"handlers": ["console", "file"], "level": "DEBUG", "propagate": False},
-        "httpcore": {"handlers": ["console", "file"], "level": "ERROR", "propagate": False},
-        "aiosqlite": {"handlers": ["console", "file"], "level": "INFO", "propagate": False},
+        "": {"handlers": ["console"], "level": "DEBUG", "propagate": False},
+        "httpcore": {"handlers": ["console"], "level": "ERROR", "propagate": False},
+        "aiosqlite": {"handlers": ["console"], "level": "INFO", "propagate": False},
     },
 }
 
 
-def configure_logging(level: LoggingLevelType = "INFO", config: dict[str, Any] | None = None) -> None:
-    log_config = copy.deepcopy(LOGGING_CONFIG)
+def configure_logging(
+    level: LoggingLevelType = "INFO",
+    config: dict[str, Any] | None = None,
+    log_to_file: bool = False,
+    logfile_location: Path | None = None,
+) -> None:
+    log_config: dict[str, Any] = copy.deepcopy(LOGGING_CONFIG)
+
+    # Add file handler if logging to file is enabled
+    if log_to_file:
+        # Determine the log file path
+        log_file_path = logfile_location / "amt.log" if logfile_location else Path("amt.log")
+
+        log_config["handlers"]["file"] = {
+            "formatter": "generic",
+            "()": "logging.handlers.RotatingFileHandler",
+            "filename": str(log_file_path),
+            "maxBytes": LOGGING_SIZE,
+            "backupCount": LOGGING_BACKUP_COUNT,
+        }
+        # Add file handler to all logger configurations
+        for logger_config in log_config["loggers"].values():
+            if "handlers" in logger_config and isinstance(logger_config["handlers"], list):
+                logger_config["handlers"].append("file")
 
     if config:
         log_config.update(config)

--- a/amt/server.py
+++ b/amt/server.py
@@ -23,7 +23,12 @@ from .middleware.htmx import HTMXMiddleware
 from .middleware.route_logging import RequestLoggingMiddleware
 from .middleware.security import SecurityMiddleware
 
-configure_logging(get_settings().LOGGING_LEVEL, get_settings().LOGGING_CONFIG)
+configure_logging(
+    get_settings().LOGGING_LEVEL,
+    get_settings().LOGGING_CONFIG,
+    get_settings().LOG_TO_FILE,
+    get_settings().LOGFILE_LOCATION,
+)
 
 logger = logging.getLogger(__name__)
 


### PR DESCRIPTION
# Description

Add configuration options to specify the logfile location and a boolean flag to indicate if logging to file should be enabled; default is False.

## Checklist

Please check all the boxes that apply to this pull request using "x":

- [X] I have tested the changes locally and verified that they work as expected.
- [X] I have followed the project's coding conventions and style guidelines.
- [X] I have rebased my branch onto the latest commit of the main branch.
- [X] I have squashed or reorganized my commits into logical units.
- [X] I have read, understood and agree to the [Developer Certificate of Origin](../blob/main/DCO.md), which this project utilizes.
