### PR TITLE
Fix HTML escaping in landing page template

### DIFF
--- a/amt/site/templates/pages/landingpage.html.j2
+++ b/amt/site/templates/pages/landingpage.html.j2
@@ -69,7 +69,7 @@
                                     <div class="rvo-layout-column rvo-layout-gap--md">
                                         <span class="rvo-text rvo-text--bold rvo-text--xl">{% trans %}Stepwise compliance with legislation{% endtrans %}</span>
                                         <span class="rvo-text rvo-text--subtle">
-                                            {% trans %}Ensure compliance with AI laws like the AI Act and{% endtrans %} <a href=\"https://minbzk.github.io/Algoritmekader/" target=\"_blank\">Algoritmekader</a>. {% trans %} Quickly check which legal frameworks apply to you.{% endtrans %}
+                                            {% trans %}Ensure compliance with AI laws like the AI Act and{% endtrans %} <a href="https://minbzk.github.io/Algoritmekader/" target="_blank">Algoritmekader</a>. {% trans %} Quickly check which legal frameworks apply to you.{% endtrans %}
                                         </span>
                                     </div>
                                 </div>


### PR DESCRIPTION
I believe this causes this link to point to the wrong place (to "https://amt.prd.apps.digilab.network/%22https://minbzk.github.io/Algoritmekader/%22"