### PR TITLE
feat: migrate sandbox deployment to zad-actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -246,6 +246,38 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
+  deploy-pr:
+    runs-on: ubuntu-latest
+    needs: [build]
+    if: github.event_name == 'pull_request'
+    steps:
+      - name: Extract metadata for Docker
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ""
+          flavor: |
+            latest=false
+
+      - name: Get GHCR package hash
+        id: get_package_hash
+        run: |
+          container_id=$(gh api --paginate -H "Accept: application/vnd.github+json" -H "X-GitHub-Api-Version: 2022-11-28" /orgs/MinBZK/packages/container/amt/versions | jq -r '.[] | select(.metadata.container.tags | contains(["${{ fromJSON(steps.meta.outputs.json).tags[0] }}"])) | .name')
+          echo "container_id=$container_id" >> "$GITHUB_OUTPUT"
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Deploy to ZAD
+        uses: RijksICTGilde/zad-actions/deploy@v2
+        with:
+          api-key: ${{ secrets.ZAD_API_KEY_DEV }}
+          project-id: amt-odc
+          deployment-name: amt-odc
+          component: component-1
+          image: ghcr.io/minbzk/amt:${{ fromJSON(steps.meta.outputs.json).tags[0] }}@${{ steps.get_package_hash.outputs.container_id }}
+          comment-on-pr: "true"
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+
   notifyMattermost:
     runs-on: ubuntu-latest
     needs:

--- a/.github/workflows/cleanup-pr.yml
+++ b/.github/workflows/cleanup-pr.yml
@@ -1,0 +1,16 @@
+name: cleanup-pr
+
+on:
+  pull_request:
+    types: [closed]
+
+jobs:
+  cleanup:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Cleanup ZAD deployment
+        uses: RijksICTGilde/zad-actions/cleanup@v2
+        with:
+          api-key: ${{ secrets.ZAD_API_KEY_DEV }}
+          project-id: amt-odc
+          deployment-name: amt-odc

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -14,6 +14,7 @@ on:
         type: choice
         options:
           - sandbox
+          - production
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
@@ -43,8 +44,13 @@ jobs:
         run: |
           case "${{ inputs.environment }}" in
             sandbox)
-              echo "project_id=amt-dev" >> "$GITHUB_OUTPUT"
+              echo "project_id=amt-odc" >> "$GITHUB_OUTPUT"
               echo "deployment_name=deployment-1" >> "$GITHUB_OUTPUT"
+              echo "component=component-1" >> "$GITHUB_OUTPUT"
+              ;;
+            production)
+              echo "project_id=amt-odc-prd" >> "$GITHUB_OUTPUT"
+              echo "deployment_name=productie" >> "$GITHUB_OUTPUT"
               echo "component=component-1" >> "$GITHUB_OUTPUT"
               ;;
             *)
@@ -54,9 +60,9 @@ jobs:
           esac
 
       - name: Deploy to ZAD
-        uses: RijksICTGilde/zad-actions/deploy@v1
+        uses: RijksICTGilde/zad-actions/deploy@v2
         with:
-          api-key: ${{ secrets.ZAD_API_KEY }}
+          api-key: ${{ inputs.environment == 'production' && secrets.ZAD_API_KEY_PRD || secrets.ZAD_API_KEY_DEV }}
           project-id: ${{ steps.zad_config.outputs.project_id }}
           deployment-name: ${{ steps.zad_config.outputs.deployment_name }}
           component: ${{ steps.zad_config.outputs.component }}


### PR DESCRIPTION
## Summary

Migrate the sandbox deployment from GitOps-based approach to direct API-based deployment using [RijksICTGilde/zad-actions](https://github.com/RijksICTGilde/zad-actions).

**Changes:**
- Remove ai-validation-infra repository checkout and sed commands
- Use `zad-actions/deploy` action for direct deployment to ZAD Operations Manager
- Map sandbox environment to `amt-dev` ZAD project

**Environment mapping:**
| Environment | ZAD Project | Deployment | Component |
|-------------|-------------|------------|-----------|
| sandbox | amt-dev | deployment-1 | component-1 |

## Required Setup

Before merging, add the following secret to this repository:

| Secret | Purpose | How to obtain |
|--------|---------|---------------|
| `ZAD_API_KEY` | ZAD Operations Manager API authentication | Request from RIG-cluster team or self-service portal |

## Post-merge cleanup

After verifying the new deployment works:
- The `GH_PAT` secret is no longer needed for this workflow and can be removed

## Notes

- **Production and BZK environments** have been removed from this workflow as they currently deploy to `digilab.network` infrastructure, not the ZAD/RIG-cluster. These environments would need separate ZAD project setup to migrate.
- This is a pure migration - same trigger (workflow_dispatch), simpler deployment mechanism

## Documentation

- [zad-actions README](https://github.com/RijksICTGilde/zad-actions)
- [ZAD Operations Manager API](https://operations-manager.rig.prd1.gn2.quattro.rijksapps.nl/api)