### PR TITLE
fix: voeg ontbrekende @permission-checks toe op twee algorithm-routes

### DIFF
--- a/amt/api/routes/algorithm.py
+++ b/amt/api/routes/algorithm.py
@@ -1121,6 +1121,7 @@ async def get_members_form(
 
 
 @router.get("/{algorithm_id}/users")
+@permission({AuthorizationResource.ALGORITHM_MEMBER: [AuthorizationVerb.READ]})
 async def get_users(
     request: Request,
     algorithm_id: int,

--- a/amt/api/routes/publish.py
+++ b/amt/api/routes/publish.py
@@ -131,6 +131,7 @@ def get_publish_breadcrumbs(algorithm_name: str, request: Request) -> list[Navig
 
 
 @router.post("/{algorithm_id}/publish/login")
+@permission({AuthorizationResource.ALGORITHM_PUBLISH: [AuthorizationVerb.CREATE]})
 async def ar_login(
     request: Request,
     algorithm_id: int,

--- a/tests/api/routes/test_publish.py
+++ b/tests/api/routes/test_publish.py
@@ -264,6 +264,26 @@ async def test_publish_without_permission_returns_404(client: AsyncClient, db: D
     assert response.status_code == 404
 
 
+@pytest.mark.asyncio
+async def test_ar_login_without_permission_is_denied(
+    client: AsyncClient, db: DatabaseTestUtils, mocker: MockerFixture
+) -> None:
+    # given a user without any authorizations on the algorithm (no init_authorizations_and_roles)
+    await db.given([default_user(), default_organization(), default_algorithm("testalgorithm1")])
+    mocker.patch("amt.middleware.csrf.CookieOnlyCsrfProtect.validate_csrf", new_callable=mocker.AsyncMock)
+    client.cookies["fastapi-csrf-token"] = "1"
+
+    # when posting to the Algoritmeregister login route for an algorithm the user has no access to
+    response = await client.post(
+        "/algorithm/1/publish/login",
+        json={"username": "test@example.com", "password": "testpassword"},
+        headers={"X-CSRF-Token": "1"},
+    )
+
+    # then the permission check denies it (consistent with the other /publish/* routes)
+    assert response.status_code == 404
+
+
 def test_get_global_steps() -> None:
     # given
     translations = get_translation("en")


### PR DESCRIPTION
## Wat

Twee endpoints misten een `@permission`-decorator die op alle vergelijkbare routes wel aanwezig is. Gevonden tijdens een interne security-audit.

### 1. `GET /algorithm/{algorithm_id}/users` — `amt/api/routes/algorithm.py:1123`

Geen `@permission`, terwijl de directe buur `GET /algorithm/{algorithm_id}/members` (regel 1046) `@permission({ALGORITHM_MEMBER: [READ]})` heeft en de overige member-routes `[UPDATE]`. De handler resolvet `algorithm.organization_id` uit het pad-`algorithm_id` en retourneert de organisatie-ledenlijst. Zonder check kan elke ingelogde gebruiker via een willekeurig `algorithm_id` de ledenlijst opvragen van een organisatie waar die geen toegang toe heeft (cross-tenant informatielek).

Toegevoegd: `@permission({ALGORITHM_MEMBER: [READ]})`.

**Open reviewvraag — graag jullie oordeel:** ik heb bewust `[READ]` gekozen, niet `[UPDATE]`. Argument voor `READ`: het is een lees-actie, en het minst-restrictieve verb dat het cross-tenant-lek dicht zonder legitiem gebruik te breken (rol 5 in `auth_setup.sql` heeft `algorithm/{id}/user → [Read]`, dus een lezer mag dit endpoint terecht aanroepen). Argument voor `UPDATE`: `/users` voedt in de praktijk vooral het member-toevoegformulier (de `search_select_field`-tak), wat functioneel bij de mutatie-flow hoort. Beide zijn verdedigbaar; dit is een keuze over het rechtenmodel die bij jullie ligt, niet bij mij. Pas gerust aan naar `[UPDATE]` als dat de bedoelde semantiek is.

### 2. `POST /algorithm/{algorithm_id}/publish/login` — `amt/api/routes/publish.py:133`

Geen `@permission`, terwijl álle andere `/publish/*`-routes (`/publish/explanation`, `/publish/status`, `/publish/connection`, `/publish/prepare`, `/publish/preview`) `@permission({ALGORITHM_PUBLISH: [CREATE]})` hebben. Hierdoor kan een gebruiker de Algoritmeregister-loginflow aansturen voor een algoritme dat niet van hen is. Hier is geen scope-twijfel: dit volgt eenduidig het bestaande `/publish/*`-patroon.

Toegevoegd: `@permission({ALGORITHM_PUBLISH: [CREATE]})`.

## Test

Regressietest `test_ar_login_without_permission_is_denied` toegevoegd, in het patroon van de bestaande `test_publish_without_permission_returns_404`.

**Eerlijk over lokale verificatie:** ik kon de assertie lokaal niet groen krijgen door een pre-bestaande template-renderfout in mijn omgeving (38 bestaande tests falen er om dezelfde reden, inclusief de zuster-test `test_publish_without_permission_returns_404` — vermoedelijk Poetry 1.8.2 lokaal vs vereiste `^2.3.4`). Wat ik wel hard heb geverifieerd: `AMTPermissionDenied` wordt mét deze fix geraised op `/publish/login` voor een gebruiker zonder rechten, en zónder de fix niet. De fix-logica is dus aantoonbaar correct; graag CI laten bevestigen dat de nieuwe test groen is (daar rendert het error-template wel).

## Scope

Minimale change: 2 decorator-regels + 1 regressietest. De access-control in amt is verder netjes opgezet (fail-closed `@permission`, geparametriseerde queries) — dit zijn twee gaten in een verder solide model.

## Bron

Interne security-audit, mei 2026. Geen exploit-detail nodig: het ontbreken van de decorator blijkt uit de code zelf.