### PR TITLE
fix: bump mako 1.3.10 naar 1.3.12 (CVE-2026-44307)

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -1619,14 +1619,14 @@ toml = "*"
 
 [[package]]
 name = "mako"
-version = "1.3.10"
+version = "1.3.12"
 description = "A super-fast templating language that borrows the best ideas from the existing templating languages."
 optional = false
 python-versions = ">=3.8"
 groups = ["main"]
 files = [
-    {file = "mako-1.3.10-py3-none-any.whl", hash = "sha256:baef24a52fc4fc514a0887ac600f9f1cff3d82c61d4d700a1fa84d597b88db59"},
-    {file = "mako-1.3.10.tar.gz", hash = "sha256:99579a6f39583fa7e5630a28c3c1f440e4e97a414b80372649c0ce338da2ea28"},
+    {file = "mako-1.3.12-py3-none-any.whl", hash = "sha256:8f61569480282dbf557145ce441e4ba888be453c30989f879f0d652e39f53ea9"},
+    {file = "mako-1.3.12.tar.gz", hash = "sha256:9f778e93289bd410bb35daadeb4fc66d95a746f0b75777b942088b7fd7af550a"},
 ]
 
 [package.dependencies]


### PR DESCRIPTION
## Wat

Trivy blokkeerde CI op een HIGH-vulnerability in `mako` 1.3.10:
**CVE-2026-44307**, path traversal via backslash-URI op Windows in
`TemplateLookup`. Opgelost in `mako` 1.3.12.

`mako` is een transitieve dependency via `alembic` en staat niet in
`pyproject.toml`. Daarom is alleen de `mako`-entry in `poetry.lock`
aangepast (versie + de twee file-hashes). De `content-hash` van de
lockfile blijft gelijk: die wordt afgeleid van de constraints in
`pyproject.toml`, niet van de versies van transitieve packages. De diff
is exact 3 regels in, 3 regels uit, uitsluitend het mako-blok.

## Hashes

De SHA-256-hashes komen van de PyPI JSON API
(`https://pypi.org/pypi/mako/1.3.12/json`), hetzelfde bronveld dat
Poetry zelf gebruikt bij het schrijven van `poetry.lock`. CI verwerpt
de build alsnog als een hash niet matcht met het gedownloade artifact,
dus een verkeerde hash faalt luid in plaats van stil.

## Test

Lokaal geverifieerd met dezelfde config als CI:

\`\`\`
trivy fs --config trivy.yaml --scanners vuln .
→ poetry.lock (poetry): 0 vulnerabilities, exit 0
\`\`\`

`mako` 1.3.10 → 1.3.12 is een patch-bump van een lib die alleen
transitief door alembic (migraties) wordt gebruikt; AMT raakt het niet
direct. De volledige backend-suite (677 tests) is op de huidige main al
groen.

## Context

Deze bump is bewust losgetrokken van #739 (de permission-check fix).
Die PR is functioneel al groen in CI (`677 passed`), maar bleef rood
door precies deze mako-CVE. Na merge van deze PR kan #739 op main
gerebased worden om volledig groen te worden.