### PR TITLE
fix: geef PR-deploy en -cleanup jobs pull-requests write permissie

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -250,6 +250,10 @@ jobs:
     runs-on: ubuntu-latest
     needs: [build-pr]
     if: github.event_name == 'pull_request' && github.event.pull_request.user.type != 'Bot'
+    permissions:
+      contents: read
+      packages: read
+      pull-requests: write
     steps:
       - name: Extract metadata for Docker
         id: meta

--- a/.github/workflows/cleanup-pr.yml
+++ b/.github/workflows/cleanup-pr.yml
@@ -8,6 +8,9 @@ jobs:
   cleanup:
     runs-on: ubuntu-latest
     if: github.event.pull_request.user.type != 'Bot'
+    permissions:
+      contents: read
+      pull-requests: write
     steps:
       - name: Cleanup ZAD deployment
         uses: RijksICTGilde/zad-actions/cleanup@v2


### PR DESCRIPTION
## Probleem

De `deploy-pr` job in `ci.yml` faalde met `gh: Resource not accessible by integration (HTTP 403)` op de PR-comment-stap van `zad-actions/deploy` (zie [run](https://github.com/MinBZK/amt/actions/runs/26050971213/job/76588829084?pr=740)).

De oorzaak ligt niet bij `zad-actions`. De `deploy-pr` job had als enige geen `permissions:` blok. Zodra een workflow ergens expliciete permissions zet (de jobs `build-pr`, `build` en `deploy` doen dat), krijgt elke job zonder eigen blok de minimale read-only tokenset in plaats van de repo-default. `zad-actions/deploy` met `comment-on-pr: true` plaatst de preview-URL als PR-comment via `gh api .../issues/{pr}/comments`, een schrijfactie die `pull-requests: write` vereist. Zonder die permissie faalt de comment-stap en valt de hele job op rood, terwijl de deploy zelf wel slaagt.

## Wijziging

- `deploy-pr` (`ci.yml`): `permissions`-blok toegevoegd met `contents: read`, `packages: read` (GHCR-versie-lookup) en `pull-requests: write` (PR-comment).
- `cleanup` (`cleanup-pr.yml`): hier zet geen andere job permissions, dus de token viel terug op de repo-default en faalde nog niet. `zad-actions/cleanup` werkt de PR-comment bij wanneer de PR sluit; een expliciet `permissions`-blok maakt dit robuust en consistent met `deploy-pr`, los van repo-instellingen.

Dit is de minimale set; de comment-functionaliteit blijft intact. `projects.yml` gebruikt een aparte PAT en heeft dit probleem niet; `deploy.yml` heeft geen PR-context.

## Effect op andere PRs

Andere openstaande PRs (zoals #740) worden groen zodra dit op `main` staat en hun CI opnieuw draait.
