### PR TITLE
Verklein aanvalsoppervlak container-image en borg het met een smoke-test

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -12,3 +12,9 @@ __pycache__/
 *$py.class
 
 .venv
+
+# Build artifacts that must come from the image build, never from a
+# developer's working tree. Without this a stale local dist/ or
+# node_modules/ would enter the build context and the image.
+node_modules/
+amt/site/static/dist/

--- a/.github/workflows/build-reusable.yml
+++ b/.github/workflows/build-reusable.yml
@@ -66,9 +66,6 @@ jobs:
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
           annotations: ${{ steps.meta.outputs.annotations }}
-          # darwin has no container image (Docker does not run on the macOS
-          # kernel) and no python:slim tag ships a darwin manifest, so this
-          # only ever resolved by accident. Build the platforms we deploy.
           platforms: linux/amd64,linux/arm64
 
       - name: Call API to upsert deployment

--- a/.github/workflows/build-reusable.yml
+++ b/.github/workflows/build-reusable.yml
@@ -66,7 +66,10 @@ jobs:
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
           annotations: ${{ steps.meta.outputs.annotations }}
-          platforms: linux/amd64,linux/arm64,darwin/amd64
+          # darwin has no container image (Docker does not run on the macOS
+          # kernel) and no python:slim tag ships a darwin manifest, so this
+          # only ever resolved by accident. Build the platforms we deploy.
+          platforms: linux/amd64,linux/arm64
 
       - name: Call API to upsert deployment
         id: upsert_deployment

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -94,6 +94,51 @@ jobs:
         run: docker compose exec -T amt alembic upgrade head
       - run: docker compose down -v --remove-orphans
 
+  # Smoke test the production image. test-compose runs against the `test`
+  # stage; nothing else starts the production stage, so a broken multi-stage
+  # build or a missing runtime dependency would otherwise only surface after
+  # deploy. This builds the default (production) target, boots it against
+  # postgres and asserts the app serves a real page with its webpack assets.
+  smoke-production:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - name: Build and start the production image
+        run: docker compose up -d --build
+      - name: Wait until the amt container is healthy
+        run: |
+          for i in $(seq 1 60); do
+            status=$(docker inspect --format '{{.State.Health.Status}}' amt-amt-1 2>/dev/null || echo missing)
+            echo "attempt $i: health=$status"
+            if [ "$status" = "healthy" ]; then exit 0; fi
+            if [ "$status" = "unhealthy" ]; then
+              docker compose logs amt
+              exit 1
+            fi
+            sleep 5
+          done
+          echo "container did not become healthy in time"
+          docker compose logs amt
+          exit 1
+      - name: Assert migrations ran in the entrypoint
+        run: docker compose logs amt | grep -q "alembic.runtime.migration"
+      - name: Assert the landing page renders with webpack assets
+        run: |
+          body=$(curl -fsS http://localhost:8070/)
+          echo "$body" | grep -qE '/static/dist/amt\.[a-z0-9]+\.js' \
+            || { echo "no hashed webpack bundle in the landing page"; echo "$body" | head -40; exit 1; }
+          echo "$body" | grep -qE '/static/dist/main\.[a-z0-9]+\.css' \
+            || { echo "no hashed css bundle in the landing page"; exit 1; }
+      - name: Assert the production image carries no node toolchain
+        run: |
+          if docker compose exec -T amt sh -c 'command -v node || command -v npm'; then
+            echo "node/npm leaked into the production image"
+            exit 1
+          fi
+          echo "no node/npm in the production image"
+      - if: always()
+        run: docker compose down -v --remove-orphans
+
   test-local-frontend:
     runs-on: ubuntu-latest
     steps:
@@ -201,7 +246,7 @@ jobs:
     secrets: inherit
 
   build:
-    needs: [test-local-frontend, test-local-backend, test-compose]
+    needs: [test-local-frontend, test-local-backend, test-compose, smoke-production]
     if: >-
       github.event_name != 'pull_request' &&
       !github.event.act &&

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,12 @@
 ARG PYTHON_VERSION=3.12-slim
 ARG NVM_VERSION=0.40.0
 
+# Build-platform side: full toolchain pinned to $BUILDPLATFORM so lint, test,
+# and webpack run natively on the CI runner instead of emulated under QEMU.
+# Anything produced here is either consumed in the same stage (lint/test) or
+# arch-independent (webpack JS/CSS/templates). The .venv built here targets
+# BUILDPLATFORM wheels and must never reach the runtime image — production
+# pulls its .venv from the separate python-deps stage below.
 FROM  --platform=$BUILDPLATFORM python:${PYTHON_VERSION} AS project-base
 ARG NVM_VERSION
 
@@ -69,10 +75,41 @@ COPY ./resources/ ./resources/
 RUN npm run build
 
 # Builder stage: produces the webpack assets that the production image needs.
-# Node, npm and nvm live here only and never reach the runtime image.
+# Node, npm and nvm live here only and never reach the runtime image. Stays on
+# BUILDPLATFORM via project-base; webpack output is arch-independent.
 FROM project-base AS asset-builder
 COPY amt/ ./amt/
 RUN npm run build
+
+# Python deps for the runtime image, deliberately built on $TARGETPLATFORM
+# (no --platform). asyncpg, psycopg2-binary, and cryptography all ship
+# arch-specific manylinux wheels; the previous setup copied the project-base
+# .venv into production, which on a linux/arm64 target produced an arm64
+# manifest with amd64 .so files that crashed at import. Splitting this stage
+# off makes the .venv match the runtime arch. Wheels are precompiled, so this
+# stage is just downloads even when QEMU emulation is in play, no compiler
+# toolchain needed.
+FROM python:${PYTHON_VERSION} AS python-deps
+
+ENV PYTHONUNBUFFERED=1 \
+    PYTHONDONTWRITEBYTECODE=1 \
+    PIP_NO_CACHE_DIR=off \
+    PIP_DISABLE_PIP_VERSION_CHECK=on \
+    PIP_DEFAULT_TIMEOUT=100 \
+    POETRY_VIRTUALENVS_IN_PROJECT=true \
+    POETRY_NO_INTERACTION=1 \
+    POETRY_HOME='/usr/local'
+
+RUN apt-get update \
+    && apt-get upgrade -y \
+    && apt-get install -y --no-install-recommends curl \
+    && rm -rf /var/lib/apt/lists/*
+
+RUN curl -sSL https://install.python-poetry.org | python3 -
+
+WORKDIR /app/
+COPY ./poetry.lock ./pyproject.toml ./
+RUN poetry install --without dev,test --no-root
 
 FROM python:${PYTHON_VERSION} AS production
 
@@ -100,8 +137,9 @@ RUN groupadd amt && \
 # current problem is that i could not get the logger to accept a path in the filerotate handler
 RUN mkdir -p /app/ && chown amt:amt /app/
 
-# Python environment built by poetry in project-base, no node/npm/nvm.
-COPY --from=project-base --chown=amt:amt /app/.venv /app/.venv
+# Python environment built by poetry in python-deps, on $TARGETPLATFORM so
+# the C extensions match the runtime arch. No node/npm/nvm.
+COPY --from=python-deps --chown=amt:amt /app/.venv /app/.venv
 ENV PATH="/app/.venv/bin:$PATH"
 
 WORKDIR /app/

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-ARG PYTHON_VERSION=3.12.7-slim
+ARG PYTHON_VERSION=3.12-slim
 ARG NVM_VERSION=0.40.0
 
 FROM  --platform=$BUILDPLATFORM python:${PYTHON_VERSION} AS project-base
@@ -21,8 +21,11 @@ ENV PYTHONUNBUFFERED=1 \
     POETRY_HOME='/usr/local' \
     NVM_DIR=/usr/local/nvm
 
-RUN apt-get update && apt-get install -y --no-install-recommends \
-    curl libpq-dev \
+# Upgrade OS packages so base-image CVEs are patched on every rebuild,
+# not frozen at the digest the python:slim tag pointed to.
+RUN apt-get update \
+    && apt-get upgrade -y \
+    && apt-get install -y --no-install-recommends curl libpq-dev \
     && rm -rf /var/lib/apt/lists/*
 
 RUN  curl -sSL https://install.python-poetry.org | python3 -
@@ -38,8 +41,8 @@ RUN mkdir -p $NVM_DIR && curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v
 
 RUN . ~/.bashrc && nvm install && nvm use
 
-RUN poetry install --without dev,test
-RUN . "$NVM_DIR/nvm.sh" && npm install
+RUN poetry install --without dev,test --no-root
+RUN . "$NVM_DIR/nvm.sh" && npm ci
 ENV PATH="$NVM_DIR/versions/node/v20.16.0/bin:$PATH"
 ENV PATH="/app/.venv/bin:$PATH"
 
@@ -65,15 +68,43 @@ COPY ./example/ ./example/
 COPY ./resources/ ./resources/
 RUN npm run build
 
-FROM project-base AS production
+# Builder stage: produces the webpack assets that the production image needs.
+# Node, npm and nvm live here only and never reach the runtime image.
+FROM project-base AS asset-builder
+COPY amt/ ./amt/
+RUN npm run build
 
+FROM python:${PYTHON_VERSION} AS production
+
+LABEL maintainer=ai-validatie@minbzk.nl \
+    organization=MinBZK \
+    license=EUPL-1.2 \
+    org.opencontainers.image.description="Algoritm Management Toolkit" \
+    org.opencontainers.image.source=https://github.com/MinBZK/amt \
+    org.opencontainers.image.licenses=EUPL-1.2
+
+ENV PYTHONUNBUFFERED=1 \
+    PYTHONDONTWRITEBYTECODE=1
+
+# Same OS upgrade as the base; the runtime image is built FROM the clean
+# python:slim and only carries libpq for psycopg, no build toolchain.
+RUN apt-get update \
+    && apt-get upgrade -y \
+    && apt-get install -y --no-install-recommends libpq5 \
+    && rm -rf /var/lib/apt/lists/*
 
 RUN groupadd amt && \
     adduser --uid 100 --system --ingroup amt amt
 
 #todo(berry): create log folder so permissions can be set to root:root
-# currenlt problem is that i could not get the logger to accept a path in the filerotate handler
-RUN chown amt:amt /app/
+# current problem is that i could not get the logger to accept a path in the filerotate handler
+RUN mkdir -p /app/ && chown amt:amt /app/
+
+# Python environment built by poetry in project-base, no node/npm/nvm.
+COPY --from=project-base --chown=amt:amt /app/.venv /app/.venv
+ENV PATH="/app/.venv/bin:$PATH"
+
+WORKDIR /app/
 
 USER amt
 
@@ -83,16 +114,20 @@ COPY --chown=root:root --chmod=755 prod.env /app/.env
 COPY --chown=root:root --chmod=755 resources /app/resources
 COPY --chown=root:root --chmod=755 LICENSE /app/LICENSE
 COPY --chown=amt:amt --chmod=755 docker-entrypoint.sh /app/docker-entrypoint.sh
-USER root
-RUN mkdir -p ./amt/site/static/dist/
-RUN chown amt:amt -R ./amt/site/static/dist/
-RUN chown amt:amt -R ./amt/site/templates/layouts/
-USER amt
-RUN npm run build
+
+# Webpack output from the asset-builder stage: the compiled dist bundle and
+# the generated base layout. No node_modules end up in the runtime image.
+COPY --from=asset-builder --chown=amt:amt /app/amt/site/static/dist/ /app/amt/site/static/dist/
+COPY --from=asset-builder --chown=amt:amt /app/amt/site/templates/layouts/ /app/amt/site/templates/layouts/
 
 ENV PYTHONPATH=/app/
-WORKDIR /app/
-
 ENV PATH="/app/:$PATH"
+
+# No curl in this image; the interpreter is always present.
+# start-period covers a cold start: alembic runs all migrations in the
+# entrypoint before uvicorn binds, which can take well over a minute on a
+# slow runner or a large migration history.
+HEALTHCHECK --interval=10s --timeout=5s --start-period=120s --retries=5 \
+    CMD ["python", "-c", "import urllib.request,sys; sys.exit(0 if urllib.request.urlopen('http://localhost:8000/health/live').status==200 else 1)"]
 
 CMD [ "docker-entrypoint.sh" ]

--- a/compose.yml
+++ b/compose.yml
@@ -5,8 +5,6 @@ services:
       dockerfile: Dockerfile
     image: ghcr.io/minbzk/amt:latest
     restart: unless-stopped
-    volumes:
-      - ./amt:/app/amt/:cached
     depends_on:
       db:
         condition: service_healthy
@@ -18,7 +16,15 @@ services:
     ports:
       - 8070:8000
     healthcheck:
-      test: ["CMD-SHELL", "curl -f http://localhost:8000/health/live || exit 1"]
+      # Python instead of curl: the production image is a clean python:slim
+      # without curl, so the check uses the interpreter that is always present.
+      test:
+        [
+          "CMD",
+          "python",
+          "-c",
+          "import urllib.request,sys; sys.exit(0 if urllib.request.urlopen('http://localhost:8000/health/live').status==200 else 1)",
+        ]
 
   db:
     image: postgres:16


### PR DESCRIPTION
## Aanleiding

De security-tab toonde 52 code-scanning alerts. Bijna alles kwam uit het container-image, niet uit AMT-code: de globale npm die met de nvm-installatie meekomt, build/test-tooling die in de productie-image achterbleef, en verouderde OS-pakketten in de base layer.

De runtime Python-dependencies zijn bewust niet aangeraakt: `authlib`, `starlette`, `h11`, `cryptography` en `mako` zijn op `main` inmiddels al via dependabot gepatcht.

## Wijzigingen

**Dockerfile**
- De `production`-stage erft niet langer van `project-base`. Node, npm en nvm leven nu uitsluitend in een aparte `asset-builder`-stage. De runtime is een schone `python:slim` met alleen de Python-venv en de webpack-output. Elimineert alle 11 alerts in de globale nvm-npm en alle 5 in dev-`node_modules`.
- `apt-get upgrade` in base en runtime, zodat OS-pakketten bij elke rebuild gepatcht worden in plaats van bevroren op een digest.
- Python-pin van het verouderde `3.12.7-slim` naar `3.12-slim`.
- `npm ci` in plaats van `npm install`; `poetry install --no-root`.
- `HEALTHCHECK` op de Python-interpreter in plaats van `curl` (zit niet meer in de schone image), `start-period` 120s want de entrypoint draait eerst alle alembic-migraties.

**CI**
- `build-reusable.yml` bouwde `linux/amd64,linux/arm64,darwin/amd64`. `darwin` heeft geen container-image; dat resolvde alleen per ongeluk met de oude single-stage Dockerfile en faalde hard op de tweede `FROM`. Verwijderd uit de matrix.
- Nieuwe `smoke-production` job: `test-compose` draait tegen de `test`-stage, niets startte de productie-stage. De job bouwt de productie-image, start hem tegen postgres, en assert dat de container healthy wordt, migraties draaiden, de landingpage rendert met de webpack-assets, en er geen node/npm in de image lekt. In de build-gate zodat een kapotte productie-image een merge blokkeert.

**compose.yml**
- De `./amt` bind-mount is verwijderd. Sinds de productie-stage de webpack-assets niet meer zelf bouwt, verborg die mount de gebakken `dist/` en de gegenereerde `base.html.j2` met een host-tree die ze niet heeft, wat `docker compose up` HTTP 500 gaf. Dit was op `main` al een latente bug. `compose.yml` is nu een correct productie-voorbeeld dat ook als dev-container draait, zoals BUILD.md en USAGE.md beschrijven.
- Healthcheck op Python in plaats van curl, gelijk aan de Dockerfile.

**.dockerignore** weert nu `node_modules/` en `amt/site/static/dist/`, zodat een stale lokale build niet de buildcontext en image in lekt.

## Resultaat (Trivy, HIGH/CRITICAL, runtime-image)

- npm (nvm-globaal + dev `node_modules`): 16 → 0
- Python runtime-deps: 0 (al gepatcht op `main`)
- OS-pakketten: 13 resterend, allemaal zonder upstream Debian-12-fix; `apt-get upgrade` haalt eruit wat beschikbaar is.

## Bekend, niet opgelost in deze PR

3 `pcre2`-CVE's tegen een `10.32-3.el8_6`-versie. Dat is een RHEL/UBI-pakket, geen apt-pakket, vermoedelijk via een transitieve wheel. Bestond al op de huidige main-image, geen regressie. Oplossen vergt wheel-tracing, buiten scope van een Dockerfile-PR.

## Validatie

- `docker compose up` wordt healthy en geeft `GET /` 200 met de webpack-assets (de bind-mount-bug die HTTP 500 gaf is daarmee aantoonbaar weg).
- De `linux/arm64`-image bouwt en draait (C-extensies asyncpg/psycopg2/cryptography laden, `amt.server` importeert).
- Geen `node`/`npm`/`nvm`/`node_modules` in de runtime-image.
- `.dockerignore` weert een stale host-`dist/`.
- Deze PR is herschreven bovenop de actuele `main` en tot één coherente commit gesquasht.