### PR TITLE
ci: prune oude PR-images uit GHCR (14-dagen retentie)

### DIFF
--- a/.github/workflows/ghcr-cleaner.yml
+++ b/.github/workflows/ghcr-cleaner.yml
@@ -5,10 +5,19 @@ on:
   pull_request:
     types:
       - closed
-  push:
-    branches:
-      - main
+  workflow_dispatch:
 
+# Retention policy for the ghcr.io/minbzk/amt container package:
+#   - main, latest and release tags (v*) are kept indefinitely.
+#   - PR images (pr-*) are removed immediately when their PR closes, and any
+#     that linger are swept once they are older than 14 days.
+#   - Untagged versions left behind by tag moves (and the per-arch children
+#     freed by the PR sweep) are removed.
+#
+# Safety: the scheduled/manual sweep runs in dry-run mode by default so the
+# deletions can be reviewed in the Actions log first. To enable live deletion,
+# set the repository variable GHCR_CLEANUP_DRY_RUN to "false"
+# (Settings -> Secrets and variables -> Actions -> Variables).
 jobs:
   delete_old_images:
     runs-on: ubuntu-latest
@@ -16,15 +25,28 @@ jobs:
       contents: read
       packages: write
     steps:
-      - name: "Delete untagged images"
-        if: github.event_name == 'schedule'
+      - name: "Delete PR images older than 14 days"
+        if: github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'
         uses: dataaxiom/ghcr-cleanup-action@v1
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
+          tags: "pr-*"
+          older-than: "14 days"
+          exclude-tags: "main,latest,v*"
+          dry-run: ${{ vars.GHCR_CLEANUP_DRY_RUN != 'false' }}
 
-      - name: "Clean up development images"
+      - name: "Delete untagged images"
+        if: github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'
+        uses: dataaxiom/ghcr-cleanup-action@v1
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          delete-untagged: true
+          exclude-tags: "main,latest,v*"
+          dry-run: ${{ vars.GHCR_CLEANUP_DRY_RUN != 'false' }}
+
+      - name: "Clean up images for the closed PR"
         if: github.event_name == 'pull_request' && (github.event.action == 'closed' || github.event.pull_request.merged == true)
         uses: dataaxiom/ghcr-cleanup-action@v1
         with:
-          tags: "pr-${{github.event.pull_request.number}}"
           token: ${{ secrets.GITHUB_TOKEN }}
+          tags: "pr-${{ github.event.pull_request.number }}"


### PR DESCRIPTION
## Waarom

De `amt` container-package telt nu **1107 versies**: **953 untagged**, **150 `pr-*`** (oudste `pr-116` uit juli 2024), 3 semver, 1 `main`, 1 `latest`.

De bestaande `ghcr-cleaner` ruimt alleen untagged op (schedule) en `pr-<N>` bij het sluiten van een PR. Die on-close-stap vangt echter alleen PR's die *na* invoering sluiten, dus oude PR-images stapelden zich op — en omdat de untagged-cleaner multi-arch-children van bestaande tags bewaart, blijven hún untagged versies ook staan.

## Wat deze PR doet

- **Nieuwe leeftijd-sweep** (schedule + handmatig): verwijdert `pr-*`-images **ouder dan 14 dagen** plus de daardoor verweesde untagged versies.
- **Behoudt altijd** `main`, `latest` en releases (`v*`).
- **On-close cleanup** van `pr-<nummer>` blijft ongewijzigd (directe opruiming).
- No-op `push: main`-trigger vervangen door `workflow_dispatch`.

## Veilige uitrol (dry-run eerst)

De sweep draait **standaard in dry-run** — hij logt wat hij zou verwijderen, zonder iets te wissen. Live verwijderen pas nadat je de repo-variabele zet:

`Settings → Secrets and variables → Actions → Variables → GHCR_CLEANUP_DRY_RUN = false`

### Verwacht effect (preview via API, peildatum 2026-05-27)
- **144** `pr-*`-images ouder dan 14 dagen → verwijderd
- **6** recente PR-images behouden (pr-746, 749, 744, 737, 738, 667)
- main, latest en de 3 semver blijven; het gros van de 953 untagged komt vrij als children van de 144 verwijderde PR-tags

Aanbevolen volgorde: mergen → `workflow_dispatch` draaien (dry-run) en de log reviewen → `GHCR_CLEANUP_DRY_RUN=false` zetten → live.

🤖 Generated with [Claude Code](https://claude.com/claude-code)