### PR TITLE
ci(deploy): also deploy production to amt-bzk-prd

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -68,6 +68,16 @@ jobs:
           component: ${{ steps.zad_config.outputs.component }}
           image: ghcr.io/minbzk/amt:${{ inputs.image_tag }}@${{ steps.get_package_hash.outputs.container_id }}
 
+      - name: Deploy to ZAD (amt-bzk-prd)
+        if: ${{ inputs.environment == 'production' }}
+        uses: RijksICTGilde/zad-actions/deploy@v4
+        with:
+          api-key: ${{ secrets.ZAD_API_KEY_BZK_PRD }}
+          project-id: amt-bzk-prd
+          deployment-name: productie
+          component: component-1
+          image: ghcr.io/minbzk/amt:${{ inputs.image_tag }}@${{ steps.get_package_hash.outputs.container_id }}
+
   notifyMattermost:
     runs-on: ubuntu-latest
     needs: [deploy]
@@ -79,5 +89,7 @@ jobs:
           TEXT: |
             :sparkles: A new version of AMT has been released on production by ${{ github.triggering_actor }} :sparkles:.
 
-            It will be available within a few minutes on https://amt.rijksapp.nl/.
+            It will be available within a few minutes on:
+            - https://amt.rijksapp.nl/
+            - https://amt.bzk.rijksapp.nl/
           MATTERMOST_USERNAME: ${{ github.triggering_actor }}


### PR DESCRIPTION
## Summary

Production deploys now also publish to the new `amt-bzk-prd` ZAD project alongside the existing `amt-odc-prd` deploy.

## Changes to `.github/workflows/deploy.yml`

1. **New `Deploy to ZAD (amt-bzk-prd)` step** — runs only when `inputs.environment == 'production'`, targets:
   - `project-id: amt-bzk-prd`
   - `component: component-1`
   - `deployment-name: productie`
   - `api-key: secrets.ZAD_API_KEY_BZK_PRD` (already added to repo secrets)
   - Same GHCR image + digest as the existing ODC step, so both projects land on the exact same artifact.

2. **Mattermost release notification** now lists both URLs as a bullet list:
   - https://amt.rijksapp.nl/
   - https://amt.bzk.rijksapp.nl/

## Notes

- Step ordering is ODC first, then BZK. If ODC fails, BZK is skipped; re-running the workflow is safe (ZAD deploys are idempotent on the same image digest).
- The Mattermost job still gates on the overall `deploy` job succeeding, so the message posts once both production deploys succeed.