### PR TITLE
ci(deploy): correct BZK ZAD project-id to amtbz-2m9

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -68,12 +68,12 @@ jobs:
           component: ${{ steps.zad_config.outputs.component }}
           image: ghcr.io/minbzk/amt:${{ inputs.image_tag }}@${{ steps.get_package_hash.outputs.container_id }}
 
-      - name: Deploy to ZAD (amt-bzk-prd)
+      - name: Deploy to ZAD (amtbz-2m9)
         if: ${{ inputs.environment == 'production' }}
         uses: RijksICTGilde/zad-actions/deploy@v4
         with:
           api-key: ${{ secrets.ZAD_API_KEY_BZK_PRD }}
-          project-id: amt-bzk-prd
+          project-id: amtbz-2m9
           deployment-name: productie
           component: component-1
           image: ghcr.io/minbzk/amt:${{ inputs.image_tag }}@${{ steps.get_package_hash.outputs.container_id }}


### PR DESCRIPTION
## Summary

Follow-up fix to #756. The new BZK production deploy step used `amt-bzk-prd` as `project-id`, which is not the actual ZAD project identifier — the real ID is `amtbz-2m9`. The first production run after merging #756 failed because of this ([run 26808878401](https://github.com/MinBZK/amt/actions/runs/26808878401/job/79033322403)).

## Changes to `.github/workflows/deploy.yml`

- `project-id: amt-bzk-prd` → `project-id: amtbz-2m9`
- Step label `Deploy to ZAD (amt-bzk-prd)` → `Deploy to ZAD (amtbz-2m9)` so the step name matches the actual ZAD project ID.

Unchanged:
- Secret name: `ZAD_API_KEY_BZK_PRD` (already set in repo secrets)
- `component: component-1`
- `deployment-name: productie`
- `if: ${{ inputs.environment == 'production' }}`
- GHCR image + digest
- Mattermost notification (still lists both URLs)