### PR TITLE
Replace AI Validatie contact details with Digi Gilde

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,7 +10,7 @@ ARG NVM_VERSION=0.40.0
 FROM  --platform=$BUILDPLATFORM python:${PYTHON_VERSION} AS project-base
 ARG NVM_VERSION
 
-LABEL maintainer=ai-validatie@minbzk.nl \
+LABEL maintainer=digigilde@rijksoverheid.nl \
     organization=MinBZK \
     license=EUPL-1.2 \
     org.opencontainers.image.description="Algoritm Management Toolkit" \
@@ -113,7 +113,7 @@ RUN poetry install --without dev,test --no-root
 
 FROM python:${PYTHON_VERSION} AS production
 
-LABEL maintainer=ai-validatie@minbzk.nl \
+LABEL maintainer=digigilde@rijksoverheid.nl \
     organization=MinBZK \
     license=EUPL-1.2 \
     org.opencontainers.image.description="Algoritm Management Toolkit" \

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ for algorithms.
 
 A demo of the tool is deployed here: https://amt.rijksapp.nl/.
 
-The tool is built by the [AI Validation Team](https://minbzk.github.io/ai-validation/).
+The tool is built by the [Digi Gilde](https://digigilde.github.io/handboek/).
 
 ## How to contribute
 

--- a/amt/site/templates/pages/landingpage.html.j2
+++ b/amt/site/templates/pages/landingpage.html.j2
@@ -130,7 +130,7 @@
             <span class="utrecht-icon rvo-icon rvo-icon-bevestiging rvo-icon--md rvo-status-icon-bevestiging rvo-icon--hemelblauw rvo-link__icon--before"
                   role="img"
                   aria-label="Pijl naar rechts"></span>
-            {% trans %}Mail us:{% endtrans %} <a href="mailto:ai-validatie@minbzk.nl" class="rvo-link">ai-validatie@minbzk.nl</a>
+            {% trans %}Mail us:{% endtrans %} <a href="mailto:digigilde@rijksoverheid.nl" class="rvo-link">digigilde@rijksoverheid.nl</a>
           </span>
           <span class="rvo-layout-column rvo-layout-align-content-center rvo-layout-row rvo-layout-gap--2xs">
             <span class="utrecht-icon rvo-icon rvo-icon-bevestiging rvo-icon--md rvo-status-icon-bevestiging rvo-icon--hemelblauw rvo-link__icon--before"

--- a/publiccode.yml
+++ b/publiccode.yml
@@ -1,8 +1,8 @@
 # This repository adheres to the publiccode.yml standard by including this
 # metadata file that makes public software easily discoverable.
-# More info at https://github.com/italia/publiccode.yml
+# More info at https://github.com/publiccodeyml/publiccode.yml
 
-publiccodeYmlVersion: "0.2"
+publiccodeYmlVersion: "0.7"
 categories:
   - it-development
 description:
@@ -12,7 +12,6 @@ description:
       - Validation
       - Transparency
       - Algorithm
-    genericName: amt
     longDescription: |
       AMT is the acronym for Algorithm Management Toolkit. The goal is to make algorithmic systems more transparent. It achieves this by generating standardized reports. These reports consist of both technical aspects as well as descriptive information about the system and regulatory assessments. For both the system and the model the lifecycle is important, so this is incorporated in both the tool as well as the reports. The definition for an algorithm is derived from the Algoritmeregister.
 
@@ -28,8 +27,8 @@ localisation:
   localisationReady: false
 maintenance:
   contacts:
-    - name: AI Validatie
-      email: ai-validatie@minbzk.nl
+    - name: Digi Gilde
+      email: digigilde@rijksoverheid.nl
   type: community
 name: amt
 platforms:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,7 +2,7 @@
 name = "amt"
 version = "0.1.0"
 description = ""
-authors = ["ai-validatie-team <ai-validatie@minbzk.nl>"]
+authors = ["Digi Gilde <digigilde@rijksoverheid.nl>"]
 readme = "README.md"
 license = "EUPL-1.2"
 repository = "https://github.com/MinBZK/amt"


### PR DESCRIPTION
Mailbox `ai-validatie@minbzk.nl` becomes `digigilde@rijksoverheid.nl` in the Dockerfile labels, `pyproject.toml`, `publiccode.yml` and the landing page. Author and contact name become Digi Gilde; the README links to the [Digi Gilde handbook](https://digigilde.github.io/handboek/).

`publiccode.yml` is brought to standard version 0.7: the deprecated `genericName` key is dropped and the header link points at the publiccodeyml organisation.

Not touched: `.github/CODEOWNERS` still names `@MinBZK/ai-validation-team`, a team that does not exist in the organisation (the team slug is `ai-validation`). To be fixed together with the other repos once the new team exists.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LfhcRiHMhCzxD52g5U582d
